### PR TITLE
State synchronization

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -71,28 +71,16 @@ angular.module('Measure', ['ionic', 'gettext', 'ngSanitize', 'ngCsv',
     });
 })
 
-.run(function ($ionicPlatform, MeasureConfig, ChromeAppSupport, ApplicationServices) {
-    $ionicPlatform.ready(function() {
-		/*
-			In Chrome, the only platform currently supported, this is handled
-			by the Background Agent. So for now, we don't have the client
-			run a scheduler service.
-				if (MeasureConfig.environmentCapabilities.schedulingSupported === true) {
-					ScheduleService.initiate();
-				}
-		*/
-		if (MeasureConfig.environmentType === 'ChromeApp') {
-			ChromeAppSupport.initialize();
-		}
-	});
+.run(function ($ionicPlatform, $rootScope, MeasureConfig, ChromeAppSupport) {
+  $ionicPlatform.ready(function() {
+    if (MeasureConfig.environmentType === 'ChromeApp') {
+      ChromeAppSupport.badge.reset();
+      ChromeAppSupport.listen(function(msg) {
+        $rootScope.$emit(msg.action, msg);
+      });
+    }
+  });
 })
-
-.value('ApplicationServices', function(ChromeAppSupport) {
-	return ChromeAppSupport;
-})
-
-
-
 .value('DialogueMessages', {
 	'historyReset': {
 		title: 'Confirm Reset',

--- a/www/js/controllers/historyCtrl.js
+++ b/www/js/controllers/historyCtrl.js
@@ -4,30 +4,24 @@ angular.module('Measure.controllers.History', [])
 		SharingService, historicalDataChartService) {
 
 	$scope.MeasureConfig = MeasureConfig;
-	$scope.historicalData = HistoryService.historicalData;
-	$scope.historicalDataChartConfig = historicalDataChartService.config;
+        $scope.series = [ "download", "upload" ];
+        $scope.data = { "series": "download" };
 
+        $scope.refreshData = function refreshData() {
+          historicalDataChartService.populateData($scope.data.series);
+          HistoryService.get().then(function(historicalData) {
+            $scope.historicalData = historicalData;
+          });
+        };
+        
+	$scope.historicalDataChartConfig = historicalDataChartService.config;
 	$scope.shareCSV = SharingService.shareCSV;
 	$scope.hideMeasurement = HistoryService.hide;
-	
-	$scope.scrollLimit = 4;
-	$scope.increaseScrollLimit = function () {
-		var scrollSize = 10;
-
-		if (($scope.scrollLimit + scrollSize) < $scope.historicalData.measurements.length) {
-			$scope.scrollLimit += scrollSize;
-		} else {
-			$scope.scrollLimit = $scope.historicalData.measurements.length;
-		}
-		$scope.$broadcast('scroll.infiniteScrollComplete');
-	}
 	/*
 		Wait until after interface is draw to populate data for UX experience,
 		and then poll recentSamples to reflect changes as the user interacts
 		with the app.
 	*/
-	historicalDataChartService.populateData();
-	$rootScope.$on('history:measurement:added',historicalDataChartService.populateData);
-	$rootScope.$on('history:measurement:removed',historicalDataChartService.populateData);
-	$rootScope.$on('history:clear',historicalDataChartService.populateData);
+	$rootScope.$on('history:measurement:change', $scope.refreshData);
+        $scope.refreshData();
 });

--- a/www/js/controllers/measureCtrl.js
+++ b/www/js/controllers/measureCtrl.js
@@ -1,10 +1,9 @@
 angular.module('Measure.controllers.Measurement', [])
 
 .controller('MeasureCtrl', function($scope, $interval, $ionicPopup, $ionicLoading,
-		MeasurementClientService, MeasurementService, SettingsService, $rootScope, StorageService, ChromeAppSupport,
+		SettingsService, $rootScope, StorageService, ChromeAppSupport,
 		MLabService, accessInformation, HistoryService, DialogueMessages,
 		progressGaugeService, MeasureConfig, connectionInformation) {
-
 
 	$ionicLoading.show({
 		templateUrl: 'templates/modals/findingServer.html',
@@ -13,104 +12,87 @@ angular.module('Measure.controllers.Measurement', [])
 		maxWidth: 200,
 		showDelay: 200
 	});
-  
-  var driveGauge = function(event, passedArguments) {
-    console.log(passedArguments.testStatus );
-    if (event.name === 'measurement:background') {
-      if (passedArguments.testStatus === 'onstart') {
-        $scope.currentState = 'Running Background Test';
-        $scope.currentRate = undefined;
-        progressGaugeService.gaugeComplete();
-        driveInteractions('start_scheduled', progressGaugeService, $interval);
-      } else if (passedArguments.testStatus === 'complete') {
-        $scope.currentState = 'Completed Background Test';
-        $scope.currentRate = passedArguments.passedResults.s2cRate;
-        progressGaugeService.gaugeReset();
-        driveInteractions('finish_scheduled', progressGaugeService, $interval);
-      } else if (passedArguments.testStatus === 'interval_c2s') {
-        $scope.currentState = 'Running Background Test (Upload)';
-        $scope.currentRate = passedArguments.passedResults.c2sRate;
-      } else if (passedArguments.testStatus === 'interval_s2c') {
-        $scope.currentState = 'Running Background Test (Download)';
-        $scope.currentRate = passedArguments.passedResults.s2cRate;
-      } else if (passedArguments.testStatus === 'onerror') {
-        progressGaugeService.gaugeError();
-        $ionicPopup.show(DialogueMessages.measurementFailure);
-        $scope.currentState = undefined;
-        $scope.currentRate = undefined;
-      }
-    } else if (event.name === 'measurement:foreground') {
-      if (passedArguments.testStatus === 'onstart') {
-        progressGaugeService.gaugeReset();
-        $scope.currentState = 'Starting';
-        $scope.currentRate = undefined;
-        driveInteractions('start_test', progressGaugeService, $interval);
-      } else if (passedArguments.testStatus === 'running_c2s') {
-        $scope.currentState = 'Running Test (Upload)';
-        driveInteractions('running_c2s', progressGaugeService, $interval);
-      } else if (passedArguments.testStatus === 'interval_c2s') {
-        $scope.currentRate = passedArguments.passedResults.c2sRate;
-      } else if (passedArguments.testStatus === 'running_s2c') {
-        $scope.currentState = 'Running Test (Download)';
-        driveInteractions('running_s2c', progressGaugeService, $interval);
-      } else if (passedArguments.testStatus === 'interval_s2c') {
-        $scope.currentRate = passedArguments.passedResults.s2cRate;
-      } else if (passedArguments.testStatus === 'complete') {
-        $scope.currentState = 'Completed';
-        $scope.currentRate = passedArguments.passedResults.s2cRate;
-        progressGaugeService.gaugeComplete();
-        driveInteractions('finished_all', progressGaugeService, $interval);
-      }
-    }
-    if (passedArguments.testStatus === 'onerror') {
-      progressGaugeService.gaugeError();
-      $ionicPopup.show(DialogueMessages.measurementFailure);
-      $scope.currentState = undefined;
-      $scope.currentRate = undefined;
-    }
-  };
 
-	var updateMLabServer = function () {
-		StorageService.get('metroSelection').then(
-			function (metroSelection) {
-				if (metroSelection === undefined || typeof(metroSelection) === 'object') {
-					metroSelection = 'automatic';
-				}
-				MLabService.findServer(SettingsService.currentSettings.metroSelection).then(
-					function(mlabAnswer) {
-						$scope.mlabInformation = mlabAnswer;
-						$scope.mlabInformation.metroSelection = SettingsService.currentSettings.metroSelection;
-						$ionicLoading.hide();
-					},
-					function () {
-						console.log("MlabNSLookupException");
-                                                $ionicLoading.hide();
-					}
-				);
-			}
-		);
-	};
-	accessInformation.getAccessInformation().then(
-		function (accessInformationResponse) {
-			$scope.accessInformation = accessInformationResponse;
-		}
-	);
-	
-	updateMLabServer();
-	
-	$rootScope.$on('settings:changed', function(event, args) {
-		if (args.name == 'metroSelection') {
-			console.log('Found new Metro server selection');
-			updateMLabServer();
-		}
-	});
+        var driveGauge = function(event, passedArguments) {
+          $scope.$apply(function() {
+            var interactionElement = document.querySelector('.interactionIcon');
+            console.log(passedArguments.testStatus );
+            $scope.measurementRunning = passedArguments.running;
+            if (event.name === 'measurement:status') {
+              if (passedArguments.testStatus === 'onstart') {
+                progressGaugeService.gaugeReset();
+                $scope.currentState = 'Starting';
+                $scope.currentRate = undefined;
+                interactionElement.src = 'img/interactions/waiting.svg';
+                interactionElement.classList.add('spinIcon');
+                interactionElement.classList.remove("testCompleted");
+              } else if (passedArguments.testStatus === 'running_c2s') {
+                $scope.currentState = 'Running Test (Upload)';
+              } else if (passedArguments.testStatus === 'interval_c2s') {
+                $scope.currentRate = passedArguments.passedResults.c2sRate;
+              } else if (passedArguments.testStatus === 'running_s2c') {
+                $scope.currentState = 'Running Test (Download)';
+              } else if (passedArguments.testStatus === 'interval_s2c') {
+                $scope.currentRate = passedArguments.passedResults.s2cRate;
+              } else if (passedArguments.testStatus === 'complete') {
+                $scope.currentState = 'Completed';
+                $scope.currentRate = passedArguments.passedResults.s2cRate;
+                interactionElement.src = 'img/interactions/okay.svg';
+                interactionElement.classList.remove('spinIcon');
+                interactionElement.classList.add('testCompleted');
+                progressGaugeService.gaugeComplete();
+              } else if (passedArguments.testStatus === 'onerror') {
+                progressGaugeService.gaugeError();
+                $ionicPopup.show(DialogueMessages.measurementFailure);
+                $scope.currentState = undefined;
+                $scope.currentRate = undefined;
+                interactionElement.classList.remove('spinIcon');
+                interactionElement.classList.remove('testCompleted');
+                interactionElement.src = 'img/interactions/play.svg';
+              }
+              progressGaugeService.setGauge(passedArguments.progress);
 
-	$rootScope.$on('measurement:foreground', driveGauge);
-	$rootScope.$on('measurement:background', driveGauge);
+            }
+          });
+        };
+
+        var updateMLabServer = function () {
+          SettingsService.get("metroSelection").then(MLabService.findServer).then(function(mlabAnswer) {
+            $scope.mlabInformation = mlabAnswer;
+            $scope.mlabInformation.metroSelection = SettingsService.currentSettings.metroSelection;
+            $ionicLoading.hide();
+          },
+          function () {
+            console.log("MlabNSLookupException");
+            $ionicLoading.hide();
+          });
+        };
+
+        updateMLabServer();
+
+        accessInformation.getAccessInformation().then(function (accessInformationResponse) {
+          $scope.accessInformation = accessInformationResponse;
+        });
+
+        $rootScope.$on('settings:changed', function(event, args) {
+          if (args.name == 'metroSelection') {
+            console.log('Found new Metro server selection');
+            updateMLabServer();
+          }
+        });
+
+	$rootScope.$on('measurement:status', driveGauge);
 
 	$scope.MeasureConfig = MeasureConfig;
-	$scope.measurementState = MeasurementService.state;
-	$scope.historyState = HistoryService.state;
+
+        function refreshHistory() {
+          HistoryService.get().then(function(data) {
+            $scope.lastMeasurementId = data.measurements.length - 1;
+          });
+        }
+
+        $rootScope.$on("history:measurement:change", refreshHistory);
+        refreshHistory();
 
 	$scope.currentState = undefined;
 	$scope.currentRate = undefined;
@@ -120,124 +102,35 @@ angular.module('Measure.controllers.Measurement', [])
 
 	$scope.connectionInformation = connectionInformation.current();
 
-	$scope.interactionHover = function (mouseIn) {
-		interactionElement = document.getElementsByClassName('interactionIcon')[0];
-		
-		if (interactionElement.classList.contains('testCompleted')) {
-			if (mouseIn === true) {
-				interactionElement.src = 'img/interactions/reload.svg';
-			} else {
-				interactionElement.src = 'img/interactions/okay.svg';
-			}
-		}
-	};
+        $scope.interactionHover = function (mouseIn) {
+          interactionElement = document.querySelector('.interactionIcon');
+          if (interactionElement.classList.contains('testCompleted')) {
+            if (mouseIn === true) {
+              interactionElement.src = 'img/interactions/reload.svg';
+            } else {
+              interactionElement.src = 'img/interactions/okay.svg';
+            }
+          }
+        };
 
-	$scope.startNDT = function() {
-		ChromeAppSupport.notify('measurement:foreground:start', {
-							'server': $scope.mlabInformation.fqdn,
-							'port': 3001,
-							'path': '/ndt_protocol',
-							'interval': 200
-						});
-		$scope.currentState = 'Starting';
+        $scope.startNDT = function() {
+          ChromeAppSupport.notify('measurement:start', {
+            'server': $scope.mlabInformation.fqdn,
+            'port': 3001,
+            'path': '/ndt_protocol',
+            'interval': 200
+          });
+          $scope.currentState = 'Starting';
 
-		if ($scope.mlabInformation === undefined) {
-			intervalPromise = $interval(function () {
-				if ($scope.mlabInformation !== undefined) {
-					$interval.cancel(intervalPromise);
-					$scope.startNDT();
-				}
-			}, 100);
-			return;
-		}
-	};
+          if ($scope.mlabInformation === undefined) {
+            intervalPromise = $interval(function () {
+              if ($scope.mlabInformation !== undefined) {
+                $interval.cancel(intervalPromise);
+                $scope.startNDT();
+              }
+            }, 100);
+            return;
+          }
+        };
 });
-
-function driveInteractions(newState, progressGaugeService, $interval) {
-	var displayArea = document.getElementsByClassName('displayArea')[0];
-	var	interactionElement,
-		temporaryElement,
-		previousElement;
-
-	if (newState === 'start_test') {
-		interactionElement = document.getElementsByClassName('interactionIcon')[0];
-		interactionElement.src = 'img/interactions/waiting.svg';
-		interactionElement.classList.add('spinIcon');
-	} else if (newState === 'start_scheduled') {
-		interactionElement = document.getElementsByClassName('interactionIcon')[0];
-		interactionElement.src = 'img/interactions/hold.svg';
-	 } else if (newState === 'finish_scheduled') {
-		interactionElement = document.getElementsByClassName('interactionIcon')[0];
-		interactionElement.src = 'img/interactions/okay.svg';
-		interactionElement.classList.remove('removedIcon');
-		interactionElement.classList.add('currentIcon');
-		interactionElement.classList.add('testCompleted');
-	 } else if (newState === 'interval_c2s') {
-		interactionElement = document.getElementsByClassName('interactionIcon')[0];
-		interactionElement.classList.remove('spinIcon');
-		interactionElement.classList.remove('currentIcon');
-		interactionElement.classList.add('removedIcon');
-
-		temporaryElement = new Image();
-		temporaryElement.src = 'img/interactions/up.svg';
-	} else if (newState === 'interval_s2c') {
-		previousElement = document.getElementsByClassName('currentIcon')[0];
-
-		temporaryElement = new Image();
-		temporaryElement.src = 'img/interactions/down.svg';
-	} else if (newState === 'finished_all') {
-		previousElement = document.getElementsByClassName('currentIcon')[0];
-
-		interactionElement = document.getElementsByClassName('interactionIcon')[0];
-		interactionElement.src = 'img/interactions/okay.svg';
-		interactionElement.classList.remove('removedIcon');
-		interactionElement.classList.add('currentIcon');
-		interactionElement.classList.add('testCompleted');
-	}
-	
-	if (temporaryElement !== undefined) {
-		temporaryElement.classList.add('gaugeIcon');
-		displayArea.appendChild(temporaryElement);
-		temporaryElement.classList.add('currentIcon');
-	}
-
-	var incrementalValue = incrementProgressMeter(newState);
-	var testPeriod = 10000,
-		intervalDelay = 100;
-	var intervalCount;
-	if (newState == 'running_s2c' || newState == 'running_c2s') {
-		intervalCount = (testPeriod / intervalDelay);
-		$interval(function () {
-			progressGaugeService.incrementGauge(incrementalValue / intervalCount);
-		}, intervalDelay, intervalCount);
-	} else {
-		progressGaugeService.incrementGauge(incrementalValue);
-	}
-
-}
-
-
-
-function incrementProgressMeter(testStatus) {
-    var testProgressIncrements = {
-        'start': .02,
-
-        'preparing_c2s': .06,
-        'running_c2s': .40,
-        'finished_c2s': .02,
-
-        'preparing_s2c': .06,
-        'running_s2c': .40,
-        'finished_s2c': .01,
-
-        'preparing_meta': .01,
-        'finished_meta': .01,
-		
-        'finished_all': .01,
-    }
-    if (testProgressIncrements.hasOwnProperty(testStatus) === true) {
-        return testProgressIncrements[testStatus];
-    }
-    return 0;
-}
 

--- a/www/js/controllers/menuCtrl.js
+++ b/www/js/controllers/menuCtrl.js
@@ -1,4 +1,13 @@
 angular.module('Measure.controllers.Menu', [])
-.controller('MenuCtrl', function($scope, HistoryService) {
-  $scope.historyState = HistoryService.state;
+.controller('MenuCtrl', function($scope, $rootScope, HistoryService) {
+  function refreshHistory() {
+    HistoryService.get().then(function(data) {
+      var dataConsumed = data.measurements.reduce(function(p,c) { return p + c.results.receivedBytes; }, 0);
+      console.log(data, dataConsumed);
+      $scope.historyState = { "dataConsumed": dataConsumed };
+    });
+  }
+
+  $rootScope.$on("history:measurement:change", refreshHistory);
+  refreshHistory();
 });

--- a/www/js/controllers/recordCtrl.js
+++ b/www/js/controllers/recordCtrl.js
@@ -28,7 +28,7 @@ angular.module('Measure.controllers.Record', [])
 		$history.back();
 	};
 
-    HistoryService.get(measurementId).then(function (measurementRecord) {
+    HistoryService.getById(measurementId).then(function (measurementRecord) {
         var measurementSiteTemp;
 
         $scope.MeasurementNotes = measurementRecord.note;
@@ -39,7 +39,7 @@ angular.module('Measure.controllers.Record', [])
         $scope.measurementRecord.index = measurementRecord.index;
 
         if (measurementRecord.timestamp !== undefined) {
-            $scope.measurementRecord.information['Time'] = $filter('date')(measurementRecord.timestamp, 'MMMM d, yyyy (H:mm)');
+            $scope.measurementRecord.information.Time = $filter('date')(measurementRecord.timestamp, 'MMMM d, yyyy (H:mm)');
         }
 
         if (measurementRecord.accessInformation !== undefined) {

--- a/www/js/controllers/settingsCtrl.js
+++ b/www/js/controllers/settingsCtrl.js
@@ -4,8 +4,7 @@ angular.module('Measure.controllers.Settings', [])
   $scope.availableSettings = SettingsService.availableSettings;
   $scope.currentSettings = SettingsService.currentSettings;
   $scope.environmentCapabilities = MeasureConfig.environmentCapabilities;
-  $scope.historyState = HistoryService.state;
-
+  
   function refreshSchedule() {
     ScheduleManagerService.getSemaphore().then(function(semaphore) {
       $scope.scheduleSemaphore = semaphore;

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -1,15 +1,43 @@
 angular.module('Measure.services.MeasurementClient', [])
 
-.factory('MeasurementClientService', function($q, MeasurementService, HistoryService, SettingsService, MLabService, accessInformation, $rootScope) {
+.factory('MeasurementClientService', function($q, MeasurementService, HistoryService, SettingsService, MLabService, accessInformation, $rootScope, ChromeAppSupport) {
 
+  function incrementProgress(current, state) {
+    var CEILINGS = {
+      "interval_c2s": 0.48,
+      "interval_s2c": 0.96,
+      "complete": 1
+    };
+
+    var DELTAS = {
+      'onstart': 0.01,
+
+      'preparing_c2s': 0.01,
+      'running_c2s': 0.01,
+      "interval_c2s": 0.01,
+      'finished_c2s': 0.02,
+
+      'preparing_s2c': 0.01,
+      'running_s2c': 0.01,
+      "interval_s2c": 0.01,
+      'finished_s2c': 0.01,
+
+      'preparing_meta': 0.01,
+      'finished_meta': 0.01,
+
+      'complete': 0.01,
+    };
+
+    var next = Math.min(current + (DELTAS[state] || 0), CEILINGS[state] || 1);
+    return next;
+  }
+  
   var MeasurementClientService = {
     "start": function start(server, port, path, interval, backgroundInitiated) {
 
       var setMetroSelection = SettingsService.currentSettings.metroSelection;
       var clientDefer = $q.defer();
-      var emitKey = (typeof backgroundInitiated !== 'undefined' ||
-                     backgroundInitiated === false) ? 'measurement:foreground' :
-                     'measurement:background';
+      var emitKey = "measurement:status";
       var measurementRecord = {
         'timestamp': Date.now(),
         'results': {},
@@ -19,13 +47,17 @@ angular.module('Measure.services.MeasurementClient', [])
         'metadata': {},
         'snapLog': {'s2cRate': [], 'c2sRate': []}
       };
+      var progress = 0;
 
       accessInformation.getAccessInformation().then(function (accessInformation) {
         measurementRecord.accessInformation = accessInformation;
       });
+      
       MLabService.findServer(setMetroSelection).then(function(mlabAnswer) {
         measurementRecord.mlabInformation = angular.copy(mlabAnswer);
         MeasurementService.start(measurementRecord.mlabInformation.fqdn, port, path, interval).then(function(passedResults) {
+          progress = incrementProgress(progress, 'complete');
+          ChromeAppSupport.notify("measurement:status", { 'testStatus': 'complete', 'passedResults': passedResults, "running": false, "progress": progress });
           $rootScope.$emit(emitKey, {
             'testStatus': 'complete',
             'passedResults': passedResults
@@ -36,9 +68,10 @@ angular.module('Measure.services.MeasurementClient', [])
             'passedResults': passedResults
           });
           measurementRecord.results = passedResults;
-          measurementRecord.lastMeasurement = HistoryService.add(measurementRecord);
+          HistoryService.add(measurementRecord);
         },
         function () {
+          ChromeAppSupport.notify("measurement:status", {'error': true, "running": false });
           $rootScope.$emit(emitKey, {'error': true});
           clientDefer.reject({'error': true});
           console.log('existing test running');
@@ -47,6 +80,8 @@ angular.module('Measure.services.MeasurementClient', [])
         function (deferredNotification) {
           var testStatus = deferredNotification.testStatus,
             passedResults = deferredNotification.passedResults;
+          progress = incrementProgress(progress, testStatus);
+          ChromeAppSupport.notify("measurement:status", {'testStatus': testStatus, 'passedResults': passedResults, "running": true, "progress": progress });
           $rootScope.$emit(emitKey, {'testStatus': testStatus, 'passedResults': passedResults});
           clientDefer.notify({
             'action': emitKey,

--- a/www/js/services/customScheduleService.js
+++ b/www/js/services/customScheduleService.js
@@ -38,12 +38,10 @@ angular.module('Measure.services.CustomSchedule', [])
       { "value": 6, "label": "Saturday" }
     ],
     "getSchedules": function getSchedules() {
-      var defer = $q.defer();
-      StorageService.get('customSchedule').then(function(customSchedule) {
+      return StorageService.get('customSchedule', []).then(function(customSchedule) {
         var now = new Date();
-        defer.resolve(customSchedule || [service.addSchedule({ "timespan": now.getHours(), "date": now.getDay() })]);
+        return customSchedule || [service.addSchedule({ "timespan": now.getHours(), "date": now.getDay() })];
       });
-      return defer.promise;
     },
     "addSchedule": function addSchedule(schedule) {
       var defer = $q.defer();
@@ -52,7 +50,7 @@ angular.module('Measure.services.CustomSchedule', [])
         defer.resolve(null);
       }
       // get stored state
-      StorageService.get('customSchedule').then(function(customSchedule) {
+      StorageService.get('customSchedule', []).then(function(customSchedule) {
         var newSchedule = customSchedule || [];
 
         // validate not already existing
@@ -72,9 +70,9 @@ angular.module('Measure.services.CustomSchedule', [])
     },
     "removeSchedule": function removeSchedule(schedule) {
       var defer = $q.defer();
-      StorageService.get('customSchedule').then(function(customSchedule) {
+      StorageService.get('customSchedule', []).then(function(customSchedule) {
         // filter based on equality
-        var newSchedule = (customSchedule || []).filter(function(s) {
+        var newSchedule = customSchedule.filter(function(s) {
           return !(s.timespan == schedule.timespan && s.date == schedule.date);
         });
         StorageService.set('customSchedule', newSchedule).then(emitChange);

--- a/www/js/services/gaugeService.js
+++ b/www/js/services/gaugeService.js
@@ -5,7 +5,7 @@ angular.module('Measure.services.Gauge', [])
 	'gaugeOptions': {
 		angle: 0.5, // The length of each line
 		lineWidth: 0.07, // The line thickness
-		limitMax: 'false',   // If true, the pointer will not go past the end of the gauge
+		limitMax: 'true',   // If true, the pointer will not go past the end of the gauge
 		colorStart: '#07DBD0',   // Colors
 		colorStop: '#07DBD0',    // just experiment with them
 		strokeColor: '#FFF',   // to see which ones work best for you
@@ -26,109 +26,112 @@ angular.module('Measure.services.Gauge', [])
 
 	progressGaugeService.gaugeStart = function () {
 		this.gaugeStatus.current = 0;
-	}
+	};
 	progressGaugeService.gaugeReset = function () {
 		this.gaugeStatus.current = 0;
-	}
+	};
 	progressGaugeService.gaugeComplete = function () {
 		this.gaugeStatus.current = this.gaugeStatus.maximum;
-	}
+	};
 	progressGaugeService.gaugeError = function () {
 		this.gaugeStatus.current = this.gaugeStatus.maximum;
 		this.gaugeConfig.colorStart = '#D90000';
 		this.gaugeConfig.colorStop = '#D90000';
-	}
-	progressGaugeService.incrementGauge = function (incrementalValue) {
-		if (this.gaugeStatus.current < this.gaugeStatus.maximum) {
-			this.gaugeStatus.current += incrementalValue;
-		}
-	}
+	};
+	progressGaugeService.setGauge = function(value) {
+          this.gaugeStatus.current = Math.min(value, this.gaugeStatus.maximum);
+        };
 	return progressGaugeService;
 })
 
 .value('historicalDataChartConfig', {
-	"options": {
-		"chart": {
-			"type": "areaspline",
-		},
-		"plotOptions": {
-			"series": {
-				"stacking": ""
-			},
-			'dataLabels': false
-		},
-		legend: {
-			enabled: false
-		},
-		tooltip: {
-			enabled: false
-		}
+  "options": {
+    "chart": {
+      "type": "areaspline",
+    },
+    "plotOptions": {
+      "series": {
+        "stacking": ""
+      },
+      'dataLabels': false
+    },
+    legend: {
+      enabled: false
+    },
+    tooltip: {
+      enabled: false
+    }
 
-	},
-	"series": [
-		{
-			title: {
-				text: null
-			},
-			"data": [],
-			"id": "series-0",
-			marker: { enabled: false },
-			color: '#9fe8e7',
-			states: { hover: { enabled: false } }
-		}
-	],
-	title: {
-		text: null
-	},
-	subtitle: {
-		text: null
-	},
-	xAxis: {
-		title: {
-			text: null
-		},
-		labels: {
-			enabled:false
-		},
-		lineWidth: 0,
-		minorGridLineWidth: 0,
-		lineColor: 'transparent',
-		minorTickLength: 0,
-		tickLength: 0
-	},
-	yAxis: {
-		title: {
-			text: null
-		},
-		labels: {
-			enabled: true,
-			align: 'left',
-			x: -2,
-			y: -2,
-			formatter: function() {
-				return (Number(this.value)/1000).toFixed(0) + ' Mbps';
-			}
-		},
-	},
-	"credits": false,
-	"loading": false,
-	"size": {
-		'height': 200
-	}
+  },
+  "series": [
+    {
+      title: {
+        text: null
+      },
+      "data": [],
+      "id": "series-0",
+      marker: { enabled: false },
+      color: '#9fe8e7',
+      states: { hover: { enabled: false } }
+    }
+  ],
+  title: {
+    text: null
+  },
+  subtitle: {
+    text: null
+  },
+  xAxis: {
+    title: {
+      text: null
+    },
+    labels: {
+      enabled:false
+    },
+    lineWidth: 0,
+    minorGridLineWidth: 0,
+    lineColor: 'transparent',
+    minorTickLength: 0,
+    tickLength: 0
+  },
+  yAxis: {
+    title: {
+      text: null
+    },
+    labels: {
+      enabled: true,
+      align: 'left',
+      x: -2,
+      y: -2,
+      formatter: function() {
+        return (Number(this.value)/1000).toFixed(0) + ' Mbps';
+      }
+    },
+  },
+  "credits": false,
+  "loading": false,
+  "size": {
+    'height': 200
+  }
 })
 
-.factory('historicalDataChartService', function(historicalDataChartConfig,
-		HistoryService) {
-	var historicalDataChartService = {};
+.factory('historicalDataChartService', function(historicalDataChartConfig, HistoryService) {
+  var historicalDataChartService = {};
 
-	historicalDataChartService.config = historicalDataChartConfig
-	
-	historicalDataChartService.populateData = function () {
-		historicalDataChartService.config.series[0].data = HistoryService.state.recentSamples;
-	}
-	historicalDataChartService.reviewData = function () {
-		return historicalDataChartService.config.series[0].data;
-	}
-	
-	return historicalDataChartService;
-})
+  historicalDataChartService.config = historicalDataChartConfig;
+
+  historicalDataChartService.populateData = function (series) {
+    HistoryService.get().then(function(historicalData) {
+      var data = historicalData.measurements.slice(-10).map(function(measurement) {
+        if (series == "upload") {
+          return measurement.results.c2sRate;
+        } else {
+          return measurement.results.s2cRate;
+        } 
+      });
+      historicalDataChartService.config.series[0].data = data;
+    });
+  };
+
+  return historicalDataChartService;
+});

--- a/www/js/services/historyService.js
+++ b/www/js/services/historyService.js
@@ -1,125 +1,66 @@
 angular.module('Measure.services.History', [])
+.factory('HistoryService', function($q, StorageService, $rootScope, ChromeAppSupport) {
+  var DEFAULT_VALUE = { "measurements": [] };  
+  var HistoryService = {};
 
+  function set(historicalData) {
+    return StorageService.set("historicalData", historicalData);
+  }
 
-.factory('HistoryService', function($q, StorageService, $rootScope) {
-	var HistoryService = {};
+  HistoryService.get = function() {
+    return StorageService.get("historicalData", DEFAULT_VALUE);
+  };
 
-	HistoryService.historicalData = {
-		'schemaVersion': 1,
-		'measurements': []
-    };
+  HistoryService.add = function (measurementRecord) {
+    return HistoryService.get().then(function(historicalData) {
+      measurementRecord.index = historicalData.measurements.length; // surrogate key, "good nuff" for now
+      historicalData.measurements.push(measurementRecord);
+      return historicalData;
+    })
+    .then(set)
+    .then(function() { ChromeAppSupport.notify('history:measurement:change', measurementRecord); });
+  };
 
-    HistoryService.state = {
-		'lastMeasurement': undefined,
-		'dataConsumed': 0,
-		'recentSamples': []
-	};
-
-	HistoryService.reIndex = function() {
-		// In order to track the same measurement across sorts, I keep an
-		// ephemeral key. I don't like this as a solution, so this should be
-		// considered a hack to replace.
-
-		var measurementId;
-		for (measurementId = 0; measurementId < this.historicalData.measurements.length; measurementId += 1) {
-			this.historicalData.measurements[measurementId].index = measurementId;
-		}
-	};
-
-
-    HistoryService.save = function () {
-		StorageService.set('historicalData', this.historicalData);
-    };
-
-	HistoryService.add = function (measurementRecord) {
-		HistoryService.historicalData.measurements.push(measurementRecord);
-		HistoryService.save();
-
-		HistoryService.state.lastMeasurement = this.historicalData.measurements.length - 1;
-		HistoryService.state.dataConsumed += measurementRecord.results.receivedBytes;
-		HistoryService.reIndex();
-		HistoryService.populateRecentSamples();
-		$rootScope.$emit('history:measurement:added', measurementRecord);
-    };
-
-    HistoryService.hide = function (measurementId) {
-		if (measurementId !== undefined) {
-			console.log('Removed measurement', measurementId);
-			HistoryService.state.dataConsumed -= HistoryService.historicalData.measurements[measurementId].results.receivedBytes;
-			HistoryService.historicalData.measurements.splice(measurementId, 1);
-			HistoryService.save();
-			HistoryService.reIndex();
-			HistoryService.populateRecentSamples();
-
-			if (HistoryService.state.lastMeasurement === measurementId ||
-          HistoryService.state.lastMeasurement === undefined) {
-				HistoryService.state.lastMeasurement = undefined;
-			} else {
-				HistoryService.state.lastMeasurement = HistoryService.historicalData.measurements.length - 1;
-			}
-			$rootScope.$emit('history:measurement:removed', measurementId);
-		}
-    };
-
-    HistoryService.annonate = function (measurementId, measurementNote) {
-		HistoryService.historicalData.measurements[measurementId].note = measurementNote;
-		HistoryService.save();
-    };
-
-    HistoryService.populateRecentSamples = function () {
-		var that = HistoryService;
-		this.state.recentSamples = [];
-		angular.forEach(this.historicalData.measurements.slice(-10),
-			function (historicalRecord) {
-				  that.state.recentSamples.push(historicalRecord.results.s2cRate);
-			}
-		);
-    };
-
-	HistoryService.get = function (measurementId) {
-        var getDeferred = $q.defer();
-        var foundResult;
-
-        if (this.historicalData.measurements.length > 0) {
-            getDeferred.resolve(this.historicalData.measurements[measurementId]);
-        } else {
-            StorageService.get('historicalData')
-				.then(function (storedHistoricalData) {
-					getDeferred.resolve(storedHistoricalData.measurements[measurementId]);
-				});
-        }
-        return getDeferred.promise;
-    };
-
-    HistoryService.reset = function () {
-		HistoryService.historicalData.measurements = [];
-		HistoryService.state.dataConsumed = 0;
-		HistoryService.state.lastMeasurement = undefined;
-		HistoryService.reIndex();
-		HistoryService.save();
-		$rootScope.$emit('history:reset');
-    };
-
-    HistoryService.restore = function () {
-		var that = this;
-
-		StorageService.get('historicalData').then(function (storedHistoricalData) {
-			if (storedHistoricalData !== undefined) {
-				that.schemaVersion = storedHistoricalData.schemaVersion;
-				angular.forEach(storedHistoricalData.measurements,
-					function (historicalRecord, historicalKey) {
-						that.historicalData.measurements.push(historicalRecord);
-						that.state.dataConsumed += historicalRecord.results.receivedBytes;
-					}
-				);
-				that.reIndex();
-				that.populateRecentSamples();
-			}
-			
+  HistoryService.hide = function (index) {
+    return HistoryService.get().then(function(historicalData) {
+      if (index >= 0 && index < historicalData.measurements.length) {
+        historicalData.measurements = historicalData.measurements.filter(function(measurement) {
+          return measurement.index != index;
         });
-    };
+      }
+      return historicalData;
+    })
+    .then(set)
+    .then(function() { ChromeAppSupport.notify('history:measurement:change', index); });
+  };
 
-	HistoryService.restore();
+  HistoryService.annonate = function (index, measurementNote) {
+    return HistoryService.get().then(function(historicalData) {
+      historicalData.measurements.some(function(measurement) {
+        if(measurement.index == index) {
+          measurement.note = measurementNote;
+          return true;
+        } else {
+          return false;
+        }
+      });
+      return historicalData;
+    }).then(set);
+  };
 
-	return HistoryService;
+  HistoryService.getById = function (index) {
+    return HistoryService.get().then(function(historicalData) {
+      var measurement = null;
+      if (index >= 0 && index < historicalData.measurements.length) {
+        measurement = historicalData.measurements[index];
+      }
+      return measurement;
+    });
+  };
+
+  HistoryService.reset = function () {
+    set(DEFAULT_VALUE).then(function() { ChromeAppSupport.notify('history:measurement:change', null); });
+  };
+  
+  return HistoryService;
 });

--- a/www/js/services/measurementService.js
+++ b/www/js/services/measurementService.js
@@ -1,72 +1,71 @@
 angular.module('Measure.services.Measurement', [])
 
 .factory("MeasurementService", ['$q', function ($q) {
-    var MeasurementService = {};
-    var MeasurementWorker = new Worker('js/measurements/ndt/ndt-worker.js');
-    var workerDeferred;
+  var MeasurementWorker = new Worker('js/measurements/ndt/ndt-worker.js');
+  var workerDeferred;
 
-    MeasurementService.state = {
-		testSemaphore: false
-	};
+  var state = {
+    testSemaphore: false
+  };
 
-    MeasurementWorker.addEventListener('message', function (e) {
-        var passedMessage = e.data;
+  MeasurementWorker.addEventListener('message', function (e) {
+    var passedMessage = e.data;
+    var deferredNotification;
+    switch (passedMessage.cmd) {
+      case 'onstart':
+        deferredNotification = {
+        'testStatus': 'onstart'
+      };
+      workerDeferred.notify(deferredNotification);
+      break;
+      case 'onstatechange':
+        deferredNotification = {
+        'testStatus': passedMessage.state,
+        'passedResults': passedMessage.results
+      };
+      workerDeferred.notify(deferredNotification);
+      break;
+      case 'onprogress':
+        deferredNotification = {
+        'testStatus': passedMessage.state,
+        'passedResults': passedMessage.results
+      };
+      workerDeferred.notify(deferredNotification);
+      break;
+      case 'onfinish':
+        state.testSemaphore = false;
+      passedMessage.results.packetRetransmissions = Number(passedMessage.results.PktsRetrans) /
+        Number(passedMessage.results.PktsOut);
+      workerDeferred.resolve(passedMessage.results);
+      break;
+      case 'onerror':
+        state.testSemaphore = false;
+      workerDeferred.reject(passedMessage.error_message);
+      break;
+    }
+  }, false);
 
-        switch (passedMessage.cmd) {
-            case 'onstart':
-                var deferredNotification = {
-                    'testStatus': 'onstart'
-                };
-                workerDeferred.notify(deferredNotification);
-                break;
-            case 'onstatechange':
-                var deferredNotification = {
-                    'testStatus': passedMessage.state,
-                    'passedResults': passedMessage.results
-                };
-                workerDeferred.notify(deferredNotification);
-                break;
-            case 'onprogress':
-                var deferredNotification = {
-                    'testStatus': passedMessage.state,
-                    'passedResults': passedMessage.results
-                };
-                workerDeferred.notify(deferredNotification);
-                break;
-            case 'onfinish':
-                MeasurementService.state.testSemaphore = false;
-                passedMessage.results.packetRetransmissions = Number(passedMessage.results.PktsRetrans) /
-                    Number(passedMessage.results.PktsOut);
-                workerDeferred.resolve(passedMessage.results);
-                break;
-            case 'onerror':
-                MeasurementService.state.testSemaphore = false;
-                workerDeferred.reject(passedMessage.error_message);
-                break;
-        }
-    }, false);
-    
-    MeasurementWorker.addEventListener('error', function (e) {
-        MeasurementService.state.testSemaphore = false;
-        workerDeferred.reject(e.lineno, ' in ', e.filename, ': ', e.message);
-    }, false);
+  MeasurementWorker.addEventListener('error', function (e) {
+    state.testSemaphore = false;
+    workerDeferred.reject(e.lineno, ' in ', e.filename, ': ', e.message);
+  }, false);
 
-    MeasurementService.start = function (hostname, port, path, update_interval) {
-        workerDeferred = $q.defer();
-        if (MeasurementService.state.testSemaphore === false) {
-            MeasurementService.state.testSemaphore = true;
-            MeasurementWorker.postMessage({
-                'cmd': 'start',
-                'hostname': hostname,
-                'port': port,
-                'path': path,
-                'update_interval': update_interval
-            });
-        } else {
-            workerDeferred.reject('test_running');
-        }
-        return workerDeferred.promise;
-    };
-
-    return MeasurementService;
+  return {
+    "start": function start(hostname, port, path, update_interval) {
+      workerDeferred = $q.defer();
+      if (state.testSemaphore === false) {
+        state.testSemaphore = true;
+        MeasurementWorker.postMessage({
+          'cmd': 'start',
+          'hostname': hostname,
+          'port': port,
+          'path': path,
+          'update_interval': update_interval
+        });
+      } else {
+        workerDeferred.reject('test_running');
+      }
+      return workerDeferred.promise;
+    }
+  };
 }]);

--- a/www/js/services/mlabService.js
+++ b/www/js/services/mlabService.js
@@ -2,96 +2,77 @@ angular.module('Measure.services.MeasurementLab', [])
 
 .factory('MLabService', function($q, $http) {
 
-	var mlabService = {};
-		 
-	mlabService.cachedResponses = {
-		'type': undefined,
-		'answer': undefined,
-		'all': undefined,
-	};
-  
-	mlabService.findServer = function (metroSelection) {
-		var findDeferred = $q.defer();
-		var temporaryCache, temporaryResponse;
-		var mlabNsUrl;
+  var CACHE = {
+    'type': undefined,
+    'answer': undefined,
+    'all': undefined,
+  };
 
-		if (metroSelection !== 'automatic') {
-			mlabNsUrl = 'http://mlab-ns.appspot.com/ndt?format=json&policy=metro&metro=' + metroSelection;
-		} else {
-			mlabNsUrl = 'http://mlab-ns.appspot.com/ndt?format=json';
-		}
+  function findServer(metroSelection) {
+    var findDeferred = $q.defer();
+    var temporaryCache, temporaryResponse;
 
-		if (this.cachedResponses.type === metroSelection && this.cachedResponses.answer !== undefined) {
-			temporaryCache = [];
-			if (mlabService.cachedResponses.all !== undefined) {
-				angular.forEach(this.cachedResponses.all, function (cachedResponse) {
-					if (cachedResponse.metro === mlabService.cachedResponses.answer.metro) {
-						temporaryCache.push(cachedResponse);
-					}
-				});
-				temporaryResponse = temporaryCache[Math.floor(Math.random() * temporaryCache.length)];
-			} else {
-				temporaryResponse = this.cachedResponses.answer;
-			}
+    if (CACHE.type === metroSelection && CACHE.answer !== undefined) {
+      if (CACHE.all !== undefined) {
+        temporaryCache = CACHE.all.filter(function(cachedResponse) { return cachedResponse.metro === CACHE.answer.metro; });
+        temporaryResponse = temporaryCache[Math.floor(Math.random() * temporaryCache.length)];
+      } else if (CACHE.answer !== undefined) {
+        temporaryResponse = CACHE.answer;
+      }
 
-			console.log('cache hit for ' + metroSelection + ' on ' +
-					this.cachedResponses.answer.site + ' sending ' +
-					temporaryResponse.fqdn);
-		 
-			findDeferred.resolve(temporaryResponse);
-		} else if (metroSelection !== 'automatic' &&
-				mlabService.cachedResponses.all !== undefined) {
-			temporaryCache = [];
-			angular.forEach(mlabService.cachedResponses.all, function (cachedResponse) {
-				if (cachedResponse.metro === metroSelection) {
-					temporaryCache.push(cachedResponse);
-				}
-			});
-			console.log('Missed cache for ' + metroSelection + ' on ' +
-					this.cachedResponses.answer + ' found all sites list ');
-			findDeferred.resolve(temporaryCache[Math.floor(Math.random() * temporaryCache.length)]);
-		} else {
-			console.log('Missed cache for ' + metroSelection );
-			this.cachedResponses.type = metroSelection;
-			$http.get(mlabNsUrl)
-				.success(function(responseObject) {
-					console.log('Received M-Lab answer ' + responseObject.fqdn +
-							' for ' + metroSelection);
-					responseObject.label = responseObject.city.replace('_', ' ');
-					responseObject.metro = responseObject.site.slice(0, 3);
-					mlabService.cachedResponses.answer = responseObject;
-					findDeferred.resolve(responseObject);
-				})
-				.error(function(data) {
-					findDeferred.reject(data);
-				});
-		}
-		return findDeferred.promise;
-	};
+      console.log('cache hit for ' + metroSelection + ' on ' + CACHE.answer.site + ' sending ' + temporaryResponse.fqdn);
 
-	mlabService.findAll = function () {
-		var findAllDeferred = $q.defer();
-		var mlabNsUrl = 'http://mlab-ns.appspot.com/ndt?format=json&policy=all';
-		 
-		if (mlabService.cachedResponses.all === undefined) {
-			$http.get(mlabNsUrl)
-				.success(function(data, status, headers, config) {
-					mlabService.cachedResponses.all = [];
-					angular.forEach(data, function (responseObject) {
-						responseObject.label = responseObject.city.replace('_', ' ');
-						responseObject.metro = responseObject.site.slice(0, 3);
-						mlabService.cachedResponses.all.push(responseObject);
-					});
-					findAllDeferred.resolve(data);
-				})
-				.error(function(data, status, headers, config) {
-					findAllDeferred.reject(data);
-				});
-		} else {
-			findAllDeferred.resolve(mlabService.cachedResponses.all);
-		}
-		return findAllDeferred.promise;
-	};
+      findDeferred.resolve(temporaryResponse);
+    } else {
+      console.log('Missed cache for ' + metroSelection );
+      var mlabNsUrl = 'http://mlab-ns.appspot.com/ndt?format=json';
+      if (metroSelection && metroSelection !== "automatic") {
+        mlabNsUrl = 'http://mlab-ns.appspot.com/ndt?format=json&policy=metro&metro=' + metroSelection;
+      }
+      CACHE.type = metroSelection;
+      $http.get(mlabNsUrl)
+      .success(function(responseObject) {
+        console.log('Received M-Lab answer ' + responseObject.fqdn +
+                    ' for ' + metroSelection);
+        responseObject.label = responseObject.city.replace('_', ' ');
+        responseObject.metro = responseObject.site.slice(0, 3);
+        CACHE.answer = responseObject;
+        findDeferred.resolve(responseObject);
+      })
+      .error(function(data) {
+        findDeferred.reject(data);
+      });
+    }
+    return findDeferred.promise;
+  }
 
-	return mlabService;
+  function findAll() {
+    var findAllDeferred = $q.defer();
+    var mlabNsUrl = 'http://mlab-ns.appspot.com/ndt?format=json&policy=all';
+
+    if (CACHE.all === undefined) {
+      $http.get(mlabNsUrl)
+      .success(function(data, status, headers, config) {
+        CACHE.all = [];
+        angular.forEach(data, function (responseObject) {
+          responseObject.label = responseObject.city.replace('_', ' ');
+          responseObject.metro = responseObject.site.slice(0, 3);
+          CACHE.all.push(responseObject);
+        });
+        findAllDeferred.resolve(data);
+      })
+      .error(function(data, status, headers, config) {
+        findAllDeferred.reject(data);
+      });
+    } else {
+      findAllDeferred.resolve(CACHE.all);
+    }
+    return findAllDeferred.promise;
+  }
+
+  return { 
+    "cachedResponses": CACHE,
+    "findServer": findServer,
+    "findAll": findAll
+  };
 });

--- a/www/js/services/scheduleService.js
+++ b/www/js/services/scheduleService.js
@@ -67,7 +67,7 @@ angular.module('Measure.services.Schedule', [])
       schedules.sort(function(a,b) { return hourOfWeek(a) < hourOfWeek(b) ? 1 : -1; });
       var next = schedules.filter(function(s) { return hourOfWeek(s) - hourOfWeek(nowHour) > 0; }).concat(schedules)[0];
 
-      var hoursToAdd = (hourOfWeek(nowHour) >= hourOfWeek(next) ? 168 /*one week in hours*/ : 0) + hourOfWeek(next) - hourOfWeek(nowHour);
+      var hoursToAdd = (hourOfWeek(nowHour) >= hourOfWeek(next) ? 169 /*one week in hours, plus 1 */ : 0) + hourOfWeek(next) - hourOfWeek(nowHour);
       var start = epochHour + (hoursToAdd * INTERVAL_MS);
       return createIntervalSemaphore(start, INTERVAL_MS);
     });

--- a/www/js/services/settingsService.js
+++ b/www/js/services/settingsService.js
@@ -4,7 +4,7 @@ angular.module('Measure.services.Settings', [])
 
   var SettingsService = {
     "get": function get(key) {
-      return StorageService.get("savedSettings").then(function(settings) {
+      return StorageService.get("savedSettings", SettingsService.availableSettings[key].default).then(function(settings) {
         return settings && key ? settings[key] : settings;
       });
     }
@@ -51,12 +51,12 @@ angular.module('Measure.services.Settings', [])
     angular.forEach(this.currentSettings, function (settingValue, settingKey) {
       savedSettings[settingKey] = settingValue;
     });
-    StorageService.set('savedSettings', savedSettings);
+    return StorageService.set('savedSettings', savedSettings);
   };
 
   SettingsService.restore = function () {
     var restoreDeferred = $q.defer();
-    StorageService.get('savedSettings').then(
+    StorageService.get('savedSettings', {}).then(
       function (savedSettings) {
         angular.forEach(SettingsService.availableSettings, function (availableSettingsValue, availableSettingsKey) {
           if (savedSettings !== undefined && savedSettings[availableSettingsKey] !== undefined) {
@@ -75,12 +75,13 @@ angular.module('Measure.services.Settings', [])
     return restoreDeferred.promise;
   };
   SettingsService.setSetting = function (requestedSettingName, requestedSettingValue) {
-    $rootScope.$emit('settings:changed', {
-      name: requestedSettingName,
-      value: requestedSettingValue
-    });
     SettingsService.currentSettings[requestedSettingName] = requestedSettingValue;
-    SettingsService.save();
+    SettingsService.save().then(function() {
+      $rootScope.$emit('settings:changed', {
+        name: requestedSettingName,
+        value: requestedSettingValue
+      });
+    });
   };
 
   SettingsService.restore();

--- a/www/js/services/storageService.js
+++ b/www/js/services/storageService.js
@@ -8,9 +8,9 @@ angular.module('Measure.services.Storage', [])
       }
       throw "No storage backend available";
     },
-    "get": function (key) {
+    "get": function (key, defaultValue) {
       if (MeasureConfig.environmentType === 'ChromeApp') {
-        return ChromeAppSupport.get(key);
+        return ChromeAppSupport.get(key, defaultValue);
       }
       throw "No storage backend available";
     }

--- a/www/templates/history.html
+++ b/www/templates/history.html
@@ -4,8 +4,8 @@
             on-tap="shareCSV(historicalData.measurements)"
 			translate>Export</button>
 	</ion-nav-buttons>
-	<ion-content class="panel__history__empty"
-				ng-show="historicalData.measurements.length === 0">
+        <div ng-if="historicalData.measurements.length === 0">
+	<ion-content class="panel__history__empty">
 		<div class="row">
 			<div class="col col-offset-25 col-50 center emptyIcon"><i class="ion-erlenmeyer-flask"></i></div>
 		</div>
@@ -13,16 +13,24 @@
 			<div class="col col-offset-25 col-50 center">No measurements yet. When you conduct tests, they will fill in here.</div>
 		</div>
 	</ion-content>
-	<ion-content class="panel__history"
-			ng-show="historicalData.measurements.length > 0">
+        </div>
+        <div ng-if="historicalData.measurements.length > 0">
+	<ion-content class="panel__history">
 			<highchart id="historicalDataChart" config="historicalDataChartConfig" class="historicalDataChart"></highchart>
 			<ion-list show-delete="false" can-swipe="true">
-				<div class="item item-divider">
+                        <label class="item item-input item-select">
+                          <div class="input-label" translate>Statistic</div>
+                          <select ng-model="data.series"
+                                  ng-change="refreshData()"
+                                  ng-options="stat as (stat | capitalize:true) for stat in series">
+                          </select>
+                        </label>
+                                <div class="item item-divider">
 					<span translate>Measurement History</span>
 					<span class="badge badge-assertive">{{ historicalData.measurements.length }} </span>
 				</div>
-				<ion-item ui-sref="app.measurementRecord({measurementId: measurementRecord.index})" ng-repeat="measurementRecord in
-								historicalData.measurements |  orderBy:'timestamp':true | limitTo: scrollLimit track by measurementRecord.index" >
+				<ion-item ui-sref="app.measurementRecord({measurementId: measurementRecord.index})" 
+                                          ng-repeat="measurementRecord in historicalData.measurements | orderBy:'timestamp':true" >
 					<div class="row" ng-if="measurementRecord.accessInformation !== undefined">
 						<div class="col">
 							<h2>{{ measurementRecord.accessInformation.isp }}</h2>
@@ -63,6 +71,6 @@
 							</ion-option-button>
 				</ion-item>
 			</ion-list>
-			<ion-infinite-scroll ng-if="(historicalData.measurements.length > scrollLimit)" on-infinite="increaseScrollLimit()" distance="10%"></ion-infinite-scroll>
 	</ion-content>
+        </div>
 </ion-view>

--- a/www/templates/measure.html
+++ b/www/templates/measure.html
@@ -25,7 +25,7 @@
         </div>
 		<div class="row padding-vertical">
 			<div class="col center displayArea"
-					ng-class="{testReady: measurementState.testSemaphore===false}">
+					ng-class="{testReady: !measurementRunning }">
 				<canvas gaugejs gauge-type="progressGaugeConfig.gaugeType"
 						class="progressGauge"
 						options="progressGaugeConfig.gaugeOptions"
@@ -66,15 +66,11 @@
 					translate>Finding Server</span>
 			</div>
         </div>
-		<div class="row" ng-show="historyState.lastMeasurement !== undefined && measurementState.testSemaphore === false">
+		<div class="row" ng-show="lastMeasurementId !== undefined && !measurementRunning">
 			<div class="col center">
 				<a class="button button-outline button-positive icon-left ion-plus-round"
-						ui-sref="app.measurementRecord({measurementId: historyState.lastMeasurement})"
+						ui-sref="app.measurementRecord({measurementId: lastMeasurementId})"
 						translate>More</a>
-				<a class="button button-outline button-balanced icon-right ion-share"
-						on-tap="shareMeasurement({{ historyState.lastMeasurement }})"
-						ng-show="MeasureConfig.sharingSupported"
-						translate>Share</a>
 			</div>
 		</div>
 		<div class="row desktop-only">


### PR DESCRIPTION
In effect, this fixes most of the UI issues where the state is not
updated (e.g. data usage, test completion, etc.)

This also moves the state management and test running to the background
page, which allows the popup to render as a view of the internal state.
This fixes the issue where the popup "loses" its place if a test is
in progress. (Settings are still saved via the popup, and then the
background page is notified to update schedules)

Simplified the measure controller and how the guage intervals were
being rendered: it should look more like 50% up, 50% down, then
complete, and shows the "More" button to add annotation to the latest
test.

Data visualization has a simple statistic toggle for "Upload" vs.
"Download".

Lots of refactoring overall, simplifying state to use StorageService and
promises to deliver the retrieved data back through the
`ChromeAppSupport.notify` message bus, which are either resolved
directly or, in the case of most controllers, via `$rootScope.$emit`
listeners.

@collina @critzo @georgiamoon 
