### PR TITLE
translation support for measurement history modal dialog

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -48,7 +48,10 @@ angular.module('Measure', ['ionic', 'gettext', 'ngSanitize',
         "Completed": gettext("Completed"),
         "{{timeofday}} hour, every {{dayofweek}}": gettext("{{timeofday}} hour, every {{dayofweek}}"),
         "Click and drag in the chart to zoom in" : gettext("Click and drag in the chart to zoom in"),
-        "Pinch the chart to zoom in": gettext("Pinch the chart to zoom in")
+        "Pinch the chart to zoom in": gettext("Pinch the chart to zoom in"),
+        "Confirm Reset": gettext("Confirm Reset"),
+        "Failure": gettext("Failure"),
+        "Dismiss": gettext("Dismiss")
     };
 })
 
@@ -141,7 +144,7 @@ angular.module('Measure', ['ionic', 'gettext', 'ngSanitize',
 .value('DialogueMessages', {
 	'historyReset': {
 		title: 'Confirm Reset',
-		template: 'This action will permanently remove all stored results and cannot be undone. Are you sure?'
+		templateUrl: 'templates/modals/messageResetHistory.html'
 	},
 	'measurementFailure': {
 		title: 'Failure',

--- a/www/templates/modals/messageResetHistory.html
+++ b/www/templates/modals/messageResetHistory.html
@@ -1,0 +1,1 @@
+<p translate>This action will permanently remove all stored results and cannot be undone. Are you sure?</p>


### PR DESCRIPTION
This PR updates the "reset measurement history" modal dialog content so that it supports translation via gettext. **This PR still needs to be built and tested.** I'll be updating my local files to build and test as well, but for expediency I've created the PR so others with an already working build system can test. @georgiamoon @sajacy  

Two files were updated (desktop and android app.js) and a template for the content of the modal dialog was added. In addition to the text string for the modal dialog, the title of this modal and a couple others were added to the manual list of strings.
