### PR TITLE
Remove hidden overflows

### DIFF
--- a/scss/custom.scss
+++ b/scss/custom.scss
@@ -157,7 +157,6 @@ span.item-note {
   max-width: 80%;
   text-overflow: ellipsis;
   display: inline-block;
-  overflow: hidden;
 }
 
 .panel__measure .padding-vertical {
@@ -165,7 +164,6 @@ span.item-note {
 }
 .panel__measure div.row div.col {
   text-overflow: ellipsis;
-  overflow: hidden;
   color: rgb(68, 68, 68);
   font-family: 'Helvetica Neue', Roboto, 'Segoe UI', sans-serif;
   font-size: 1.2em;


### PR DESCRIPTION
Addresses #76 . Can't test this locally (no Chromebook, unfortunately) but I've removed the instances of `overflow: hidden` that might be causing the scrolling issue.  Regression tested the extension - doesn't seem to cause any display issues. 
