### PR TITLE
Pin highcharts-ng to pre-1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "angular-aria": "*",
     "angular-gettext": "*",
     "highcharts": "*",
-    "highcharts-ng": "*",
+    "highcharts-ng": "~0.0.13",
     "sajacy-gauge.js": "~1.2.2"
   },
   "resolutions": {


### PR DESCRIPTION
Since app is built with Angular 1.4.3, it's not compatible with the [1.x branch of highcharts-ng](https://github.com/pablojim/highcharts-ng/releases/tag/1.0.0).  Explicitly pinning the bower dependency list to the latest compatible version.

@georgiamoon 