### PR TITLE
Replace measure-location with ipinfo

### DIFF
--- a/www/js/controllers/recordCtrl.js
+++ b/www/js/controllers/recordCtrl.js
@@ -43,7 +43,7 @@ angular.module('Measure.controllers.Record', [])
         }
 
         if (measurementRecord.accessInformation !== undefined) {
-            $scope.measurementRecord.information['Service Provider'] = measurementRecord.accessInformation.isp;
+            $scope.measurementRecord.information['Service Provider'] = measurementRecord.accessInformation.org;
         }
         if (measurementRecord.mlabInformation !== undefined && measurementRecord.mlabInformation !== null) {
             measurementSiteTemp = measurementRecord.mlabInformation.fqdn.split('.');

--- a/www/js/services/networkService.js
+++ b/www/js/services/networkService.js
@@ -10,13 +10,19 @@ angular.module('Measure.services.Network', [])
 		var deferred = $q.defer();
 		$http.get(ACCESS_SERVICE_URL)
 			.success(function (data) {
-					chrome.extension.getBackgroundPage().console.log(data);
 					accessInformation.currentAccessInformation = data;
+
+					// Split ASN and ISP name.
+					asnRegex = new RegExp('^(AS[0-9]+)\\w+(.+)')
+					accessInformation.currentAccessInformation.asn =
+						accessInformation.currentAccessInformation.org.replace(asnRegex, "$1");
+					accessInformation.currentAccessInformation.org =
+						accessInformation.currentAccessInformation.org.replace(asnRegex, "$2");
+
 					deferred.resolve(accessInformation.currentAccessInformation);
 				}
 			)
 			.error(function (data) {
-					chrome.extension.getBackgroundPage().console.log(data);
 					accessInformation.currentAccessInformation = {};
 					deferred.reject(data);
 				}

--- a/www/js/services/networkService.js
+++ b/www/js/services/networkService.js
@@ -1,6 +1,6 @@
 angular.module('Measure.services.Network', [])
 
-.constant('ACCESS_SERVICE_URL', 'https://measure-location.appspot.com')
+.constant('ACCESS_SERVICE_URL', 'https://ipinfo.io')
 
 .factory('accessInformation', function($q, $http, ACCESS_SERVICE_URL) {
 	var accessInformation = {};
@@ -10,11 +10,13 @@ angular.module('Measure.services.Network', [])
 		var deferred = $q.defer();
 		$http.get(ACCESS_SERVICE_URL)
 			.success(function (data) {
+					chrome.extension.getBackgroundPage().console.log(data);
 					accessInformation.currentAccessInformation = data;
 					deferred.resolve(accessInformation.currentAccessInformation);
 				}
 			)
 			.error(function (data) {
+					chrome.extension.getBackgroundPage().console.log(data);
 					accessInformation.currentAccessInformation = {};
 					deferred.reject(data);
 				}

--- a/www/templates/history.html
+++ b/www/templates/history.html
@@ -29,11 +29,11 @@
 					<span translate>Measurement History</span>
 					<span class="badge badge-assertive">{{ historicalData.measurements.length }} </span>
 				</div>
-				<ion-item ui-sref="app.measurementRecord({measurementId: measurementRecord.index})" 
+				<ion-item ui-sref="app.measurementRecord({measurementId: measurementRecord.index})"
                                           ng-repeat="measurementRecord in historicalData.measurements | orderBy:'timestamp':true" >
 					<div class="row" ng-if="measurementRecord.accessInformation !== undefined">
 						<div class="col">
-							<h2>{{ measurementRecord.accessInformation.isp }}</h2>
+							<h2>{{ measurementRecord.accessInformation.org }}</h2>
 						</div>
 						<div class="col col-25 right">
 							<h4>{{ measurementRecord.timestamp | date:'MMMM d' }}</h4>

--- a/www/templates/measure.html
+++ b/www/templates/measure.html
@@ -16,8 +16,8 @@
         </div>
         <div class="row padding-vertical">
 			<div class="col center">
-				<i class="icon ion-cloud currentNetwork" ng-show="!accessInformation.isp"></i>
-				<span class="currentNetwork" ng-bind="accessInformation.isp"></span>
+				<i class="icon ion-cloud currentNetwork" ng-show="!accessInformation.org"></i>
+				<span class="currentNetwork" ng-bind="accessInformation.org"></span>
 			</div>
         </div>
 		<div class="row padding-vertical">


### PR DESCRIPTION
This PR removes the dependency on the measure-location service and replaces it with an unauthenticated request to ipinfo.io instead. This allows us to keep displaying the user's ISP and also to gather some additional info (estimated latitude/longitude, city, postal code, etc) which will go in the CSV output.

Since this is just a single request when the user displays the extension's popup, the limit of 1000 requests / day / IP should never be reached.