### PR TITLE
Rename Mbps -> Mbit/s

### DIFF
--- a/scss/custom.scss
+++ b/scss/custom.scss
@@ -131,7 +131,7 @@ span.measurement-icon:before {
 }
 
 .panel__measure .spinIcon {
-  animation-name: spin; 
+  animation-name: spin;
   animation-duration: 2000ms; /* 40 seconds */
   animation-iteration-count: infinite;
   animation-timing-function: linear;
@@ -198,6 +198,7 @@ span.item-note {
 }
 
 .panel__measure div.row div.col span.currentRateLabel {
+  margin-left: 0.6em;
   font-size: 0.9em;
   font-weight: 100;
 

--- a/www/js/filters.js
+++ b/www/js/filters.js
@@ -9,9 +9,9 @@ angular.module('Measurement.filters', [])
 .filter('formatThroughputMeasurement', function() {
   return function(input) {
     var filteredInput;
-    
+
     if (input !== undefined) {
-         filteredInput = String((Number(input) / 1000).toFixed(2)); // + " Mbps";
+         filteredInput = String((Number(input) / 1000).toFixed(2)); // + " Mbit/s";
     } else {
         filteredInput = '';
     }
@@ -22,9 +22,9 @@ angular.module('Measurement.filters', [])
 .filter('formatThroughputDisplay', function() {
   return function(input) {
     var filteredInput;
-    
+
     if (input !== undefined) {
-         filteredInput = String((Number(input) / 1000).toFixed(2)) + " Mbps";
+         filteredInput = String((Number(input) / 1000).toFixed(2)) + " Mbit/s";
     } else {
         filteredInput = '';
     }
@@ -41,9 +41,9 @@ angular.module('Measurement.filters', [])
 .filter('formatDataConsumptionMeasurement', function() {
   return function(input) {
     if (Number(input) > Math.pow(1000, 3)) {
-        return String((Number(input) / Math.pow(1000, 3)).toFixed(2)) + " Gb";
+        return String((Number(input) / Math.pow(1000, 3)).toFixed(2)) + " Gbit";
     }
-    return String((Number(input) / Math.pow(1000, 2)).toFixed(2)) + " Mb";
+    return String((Number(input) / Math.pow(1000, 2)).toFixed(2)) + " Mbit";
   };
 })
 

--- a/www/js/services/chartService.js
+++ b/www/js/services/chartService.js
@@ -12,7 +12,7 @@ angular.module('Measure.services.Chart', [])
         "tooltip": {
             headerFormat: '',
             pointFormatter: function() {
-               return (Number(this.y)/1000).toFixed(2) + ' Mbps';
+               return (Number(this.y)/1000).toFixed(2) + ' Mbit/s';
             }
           }
       },
@@ -68,7 +68,7 @@ angular.module('Measure.services.Chart', [])
       x: -2,
       y: -2,
       formatter: function() {
-        return (Number(this.value)/1000).toFixed(0) + ' Mbps';
+        return (Number(this.value)/1000).toFixed(0) + ' Mbit/s';
       }
     },
   },

--- a/www/js/services/sharingService.js
+++ b/www/js/services/sharingService.js
@@ -65,7 +65,7 @@ angular.module('Measure.services.Sharing', [])
   };
 
   var formatMbps = function formatMbps(input) {
-    return (parseFloatSafe(input) / 1000).toFixed(2) + " Mbps";
+    return (parseFloatSafe(input) / 1000).toFixed(2) + " Mbit/s";
   };
 
   var flatten = function flatten(obj, prefix, tgt) {

--- a/www/templates/measure.html
+++ b/www/templates/measure.html
@@ -41,7 +41,7 @@
         <div class="row status_row" ng-show="currentRate !== undefined">
 			<div class="col center">
 				<span class="currentRate" ng-bind="currentRate | formatThroughputMeasurement"></span>
-				<span class="currentRateLabel" ng-show="currentRate !== undefined" translate>Mbps</span>
+				<span class="currentRateLabel" ng-show="currentRate !== undefined" translate>Mbit/s</span>
 			</div>
         </div>
         <div class="row padding-vertical status_row">


### PR DESCRIPTION
This PR changes Mbps to Mbit/s everywhere. It also adds a bit of margin-left on the main (measure) view so that speeds > 100 Mbit/s don't overlap with the `Mbit/s` label.