### PR TITLE
Implement upload at the end of a test + settings page

### DIFF
--- a/resources/manifest.extension.json
+++ b/resources/manifest.extension.json
@@ -22,6 +22,7 @@
       "js/services/settingsService.js",
       "js/services/sharingService.js",
       "js/services/storageService.js",
+      "js/services/uploadService.js",
       "js/support.js",
       "js/support/chromeApp/appLauncher.js",
       "js/support/chromeApp/appSupport.js",

--- a/www/index.html
+++ b/www/index.html
@@ -20,7 +20,7 @@
     <script src="lib/highcharts-ng/dist/highcharts-ng.js"></script>
 
     <script src="lib/sajacy-gauge.js/dist/gauge.min.js"></script>
-    
+
     <script src="lib/angular-sanitize/angular-sanitize.min.js"></script>
 
     <script src="lib/angular-gettext/dist/angular-gettext.js"></script>
@@ -68,6 +68,7 @@
     <script src="js/services/settingsService.js"></script>
     <script src="js/services/sharingService.js"></script>
     <script src="js/services/storageService.js"></script>
+    <script src="js/services/uploadService.js"></script>
 
     <script src="js/support.js"></script>
     <script src="js/support/chromeApp/appSupport.js"></script>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -242,6 +242,16 @@ angular.module('Measure', ['ionic', 'gettext', 'ngSanitize',
     },
   })
 
+  .state('app.uploadSettings', {
+    url: "/settings/upload",
+    views: {
+      'menuContent': {
+        templateUrl: "templates/uploadSettings.html",
+        controller: 'UploadSettingsCtrl'
+      }
+    },
+  })
+
   .state('app.history', {
     url: "/history",
     views: {

--- a/www/js/controllers/settingsCtrl.js
+++ b/www/js/controllers/settingsCtrl.js
@@ -86,27 +86,15 @@ angular.module('Measure.controllers.Settings', [])
     return metroSelection.metro === 'automatic' ? 0 : metroSelection;
   };
 })
-.controller('UploadSettingsCtrl', function($scope, $ionicLoading, SettingsService, UploadService) {
+.controller('UploadSettingsCtrl', function($scope, $ionicLoading, $http, SettingsService, UploadService) {
   $scope.availableSettings = SettingsService.availableSettings;
   $scope.currentSettings = SettingsService.currentSettings;
 
   $scope.setUploadEnabled = function() {
     SettingsService.setSetting("uploadEnabled", $scope.currentSettings.uploadEnabled);
-  }
+  };
 
-  $scope.testAndSave = function() {
-    $ionicLoading.show({
-      content: 'Finding Servers',
-      animation: 'fade-in',
-      showBackdrop: false,
-      maxWidth: 200,
-    });
-
-    UploadService.uploadMeasurement({})
-      .error(function(data, status) {
-        chrome.extension.getBackgroundPage().console.log(status);
-      })
-
-    $ionicLoading.Hide();
-  }
+  $scope.onChange = function(key, value) {
+    SettingsService.setSetting(key, value);
+  };
 })

--- a/www/js/controllers/settingsCtrl.js
+++ b/www/js/controllers/settingsCtrl.js
@@ -4,7 +4,7 @@ angular.module('Measure.controllers.Settings', [])
   $scope.availableSettings = SettingsService.availableSettings;
   $scope.currentSettings = SettingsService.currentSettings;
   $scope.environmentCapabilities = MeasureConfig.environmentCapabilities;
-  
+
   function refreshSchedule() {
     ScheduleManagerService.getSemaphore().then(function(semaphore) {
       $scope.scheduleSemaphore = semaphore;
@@ -85,4 +85,28 @@ angular.module('Measure.controllers.Settings', [])
   $scope.metroSelectionSort = function(metroSelection) {
     return metroSelection.metro === 'automatic' ? 0 : metroSelection;
   };
-});
+})
+.controller('UploadSettingsCtrl', function($scope, $ionicLoading, SettingsService, UploadService) {
+  $scope.availableSettings = SettingsService.availableSettings;
+  $scope.currentSettings = SettingsService.currentSettings;
+
+  $scope.setUploadEnabled = function() {
+    SettingsService.setSetting("uploadEnabled", $scope.currentSettings.uploadEnabled);
+  }
+
+  $scope.testAndSave = function() {
+    $ionicLoading.show({
+      content: 'Finding Servers',
+      animation: 'fade-in',
+      showBackdrop: false,
+      maxWidth: 200,
+    });
+
+    UploadService.uploadMeasurement({})
+      .error(function(data, status) {
+        chrome.extension.getBackgroundPage().console.log(status);
+      })
+
+    $ionicLoading.Hide();
+  }
+})

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -9,5 +9,6 @@ angular.module('Measure.services', [
   'Measure.services.Schedule',
   'Measure.services.Settings',
   'Measure.services.Sharing',
-  'Measure.services.Storage'
+  'Measure.services.Storage',
+  'Measure.services.Upload'
 ]);

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -71,6 +71,17 @@ angular.module('Measure.services.MeasurementClient', [])
           });
           measurementRecord.results = passedResults;
           HistoryService.add(measurementRecord);
+
+          // Send data to a measure-saver instance.
+          // TODO: check uploading is enabled.
+          chrome.extension.getBackgroundPage().console.log(measurementRecord);
+          UploadService.uploadMeasurement(measurementRecord)
+            .success(function(data) {
+              ChromeAppSupport.notify('upload:success', data);
+            })
+            .error(function(data, status) {
+              ChromeAppSupport.notify('upload:failure', { "status": status, "data": data })
+            });
         },
         function () {
           ChromeAppSupport.notify('measurement:status', {'error': true, 'running': false });

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -1,6 +1,8 @@
 angular.module('Measure.services.MeasurementClient', [])
 
-.factory('MeasurementClientService', function($q, MeasurementService, HistoryService, SettingsService, MLabService, accessInformation, $rootScope, ChromeAppSupport) {
+.factory('MeasurementClientService', function($q, MeasurementService,
+  HistoryService, SettingsService, MLabService, accessInformation, $rootScope,
+  ChromeAppSupport, UploadService) {
 
   function incrementProgress(current, state) {
     var CEILINGS = {
@@ -73,17 +75,17 @@ angular.module('Measure.services.MeasurementClient', [])
           HistoryService.add(measurementRecord);
 
           // Send data to a measure-saver instance.
-          // TODO: check uploading is enabled.
-          if (SettingsService.get('uploadEnabled')) {
-            ChromeAppSupport.notify('upload:sending', 'Upload is enabled, sending measurement...');
-            UploadService.uploadMeasurement(measurementRecord)
+          SettingsService.get('uploadEnabled').then(function(enabled) {
+            if (enabled) {
+              UploadService.uploadMeasurement(measurementRecord)
               .success(function(data) {
                 ChromeAppSupport.notify('upload:success', data);
               })
               .error(function(data, status) {
                 ChromeAppSupport.notify('upload:failure', { "status": status, "data": data })
               });
-          }
+            }
+          });
         },
         function () {
           ChromeAppSupport.notify('measurement:status', {'error': true, 'running': false });

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -74,14 +74,16 @@ angular.module('Measure.services.MeasurementClient', [])
 
           // Send data to a measure-saver instance.
           // TODO: check uploading is enabled.
-          chrome.extension.getBackgroundPage().console.log(measurementRecord);
-          UploadService.uploadMeasurement(measurementRecord)
-            .success(function(data) {
-              ChromeAppSupport.notify('upload:success', data);
-            })
-            .error(function(data, status) {
-              ChromeAppSupport.notify('upload:failure', { "status": status, "data": data })
-            });
+          if (SettingsService.get('uploadEnabled')) {
+            ChromeAppSupport.notify('upload:sending', 'Upload is enabled, sending measurement...');
+            UploadService.uploadMeasurement(measurementRecord)
+              .success(function(data) {
+                ChromeAppSupport.notify('upload:success', data);
+              })
+              .error(function(data, status) {
+                ChromeAppSupport.notify('upload:failure', { "status": status, "data": data })
+              });
+          }
         },
         function () {
           ChromeAppSupport.notify('measurement:status', {'error': true, 'running': false });

--- a/www/js/services/settingsService.js
+++ b/www/js/services/settingsService.js
@@ -42,6 +42,7 @@ angular.module('Measure.services.Settings', [])
     },
     'uploadEnabled': {
       'default': false,
+      'type': 'boolean',
     },
     'uploadURL': {
       'default': '',

--- a/www/js/services/settingsService.js
+++ b/www/js/services/settingsService.js
@@ -39,6 +39,13 @@ angular.module('Measure.services.Settings', [])
     'scheduleInterval': {
       'default': 'daily',
       'options': ['constantly', 'hourly', 'daily', 'weekly', 'custom'],
+    },
+    'uploadEnabled': {
+      'default': false,
+    },
+    'uploadURL': {
+      'default': '',
+      'type': 'string',
     }
   };
 

--- a/www/js/services/settingsService.js
+++ b/www/js/services/settingsService.js
@@ -46,6 +46,18 @@ angular.module('Measure.services.Settings', [])
     'uploadURL': {
       'default': '',
       'type': 'string',
+    },
+    'uploadApiKey': {
+      'default': '',
+      'type': 'string',
+    },
+    'browserID': {
+      'default': '',
+      'type': 'string',
+    },
+    'deviceType': {
+      'default': '',
+      'type': 'string',
     }
   };
 

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -1,0 +1,33 @@
+angular.module('Measure.services.Upload', [])
+.factory('UploadService', function ($q, $http, SettingsService) {
+    var UploadService = {};
+
+    UploadService.uploadMeasurement = function(record) {
+        // This function should never be called if the upload feature is not
+        // enabled in the extension's settings.
+        if (!SettingsService.get("uploadEnabled")) {
+            return;
+        }
+
+        uploadURL = SettingsService.get("uploadURL");
+        browserID = SettingsService.get("browserID");
+
+        // Generate a valid Measurement message for measure-saver.
+        var measurement = {
+            "BrowserID": browserID,
+            "Download": record.results.s2cRate,
+            "Upload": record.results.c2sRate,
+            "Latency": parseInt(record.results.MinRTT),
+            "Results": record.results,
+        }
+        chrome.extension.getBackgroundPage().console.log(measurement);
+        return $http.post(uploadURL, measurement);
+    };
+
+    UploadService.testURL = function() {
+        uploadURL = SettingsService.get("uploadURL")
+        return $http.get(uploadURL)
+    }
+
+    return UploadService;
+});

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -11,16 +11,17 @@ angular.module('Measure.services.Upload', [])
 
         uploadURL = SettingsService.get("uploadURL");
         browserID = SettingsService.get("browserID");
+        deviceType = SettingsService.get("deviceType");
 
         // Generate a valid Measurement message for measure-saver.
         var measurement = {
             "BrowserID": browserID,
+            "DeviceType": deviceType,
             "Download": record.results.s2cRate,
             "Upload": record.results.c2sRate,
             "Latency": parseInt(record.results.MinRTT),
             "Results": record.results,
         }
-        chrome.extension.getBackgroundPage().console.log(measurement);
         return $http.post(uploadURL, measurement);
     };
 

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -3,15 +3,17 @@ angular.module('Measure.services.Upload', [])
     var UploadService = {};
 
     UploadService.uploadMeasurement = function(record) {
+        var settings = SettingsService.currentSettings
+
         // This function should never be called if the upload feature is not
         // enabled in the extension's settings.
-        if (!SettingsService.get("uploadEnabled")) {
+        if (!settings.uploadEnabled) {
             return;
         }
 
-        uploadURL = SettingsService.get("uploadURL");
-        browserID = SettingsService.get("browserID");
-        deviceType = SettingsService.get("deviceType");
+        uploadURL = settings.uploadURL;
+        browserID = settings.browserID;
+        deviceType = settings.deviceType;
 
         // Generate a valid Measurement message for measure-saver.
         var measurement = {
@@ -24,11 +26,6 @@ angular.module('Measure.services.Upload', [])
         }
         return $http.post(uploadURL, measurement);
     };
-
-    UploadService.testURL = function() {
-        uploadURL = SettingsService.get("uploadURL")
-        return $http.get(uploadURL)
-    }
 
     return UploadService;
 });

--- a/www/templates/settings.html
+++ b/www/templates/settings.html
@@ -5,6 +5,10 @@
     <span translate>Location</span>
     <i class="icon ion-chevron-right"></i>
   </a>
+  <a class="item item-icon-right" ui-sref="app.uploadSettings()" >
+    <span translate>Upload</span>
+    <i class="icon ion-chevron-right"></i>
+  </a>
   <!-- -->
   <ion-toggle ng-model="currentSettings.scheduledTesting"
               ng-if="environmentCapabilities.schedulingSupported"

--- a/www/templates/uploadSettings.html
+++ b/www/templates/uploadSettings.html
@@ -1,0 +1,33 @@
+<ion-view view-title="{{ 'Upload settings' | translate }}">
+  <ion-content>
+
+    <ion-toggle ng-model="currentSettings.uploadEnabled" ng-change="setUploadEnabled()">
+      <span translate>Upload measurements</span>
+    </ion-toggle>
+
+    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+      <span class="input-label">Server URL</span>
+      <input type="text" ng-model="currentSettings.uploadURL"></input>
+    </label>
+
+    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+      <span class="input-label">API key</span>
+      <input type="text" ng-model="currentSettings.uploadAPIKey"></input>
+    </label>
+
+    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+      <span class="input-label">Browser ID</span>
+      <input type="text" ng-model="currentSettings.browserID"></input>
+    </label>
+
+    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+      <span class="input-label">Device type</span>
+      <input type="text" ng-model="currentSettings.deviceType"></input>
+    </label>
+
+    <button class="button button-block button-positive" ng-click="testAndSave()">
+      Test & Save
+    </button>
+
+  </ion-content>
+</ion-view>

--- a/www/templates/uploadSettings.html
+++ b/www/templates/uploadSettings.html
@@ -7,27 +7,27 @@
 
     <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
       <span class="input-label">Server URL</span>
-      <input type="text" ng-model="currentSettings.uploadURL"></input>
+      <input type="text" ng-model="currentSettings.uploadURL"
+        ng-change="onChange('uploadURL', currentSettings.uploadURL)"></input>
     </label>
 
     <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
       <span class="input-label">API key</span>
-      <input type="text" ng-model="currentSettings.uploadAPIKey"></input>
+      <input type="text" ng-model="currentSettings.uploadAPIKey"
+        ng-change="onChange('uploadAPIKey', currentSettings.uploadAPIKey)"></input>
     </label>
 
     <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
       <span class="input-label">Browser ID</span>
-      <input type="text" ng-model="currentSettings.browserID"></input>
+      <input type="text" ng-model="currentSettings.browserID"
+        ng-change="onChange('browserID', currentSettings.browserID)"></input>
     </label>
 
     <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
       <span class="input-label">Device type</span>
-      <input type="text" ng-model="currentSettings.deviceType"></input>
+      <input type="text" ng-model="currentSettings.deviceType"
+        ng-change="onChange('deviceType', currentSettings.deviceType)"></input>
     </label>
-
-    <button class="button button-block button-positive" ng-click="testAndSave()">
-      Test & Save
-    </button>
 
   </ion-content>
 </ion-view>


### PR DESCRIPTION
This PR adds a new "Upload" section in the extension's settings that allows the user to specify the measure-saver's URL, API key, browser ID, and device type. When the measurements upload is enabled, an attempt to upload the test result will be made at the end of each run.