### PR TITLE
Add UI feedback after upload + allow user to retry upload

### DIFF
--- a/scss/custom.scss
+++ b/scss/custom.scss
@@ -222,3 +222,7 @@ span.item-note {
   resize: none;
   overflow: scroll;
 }
+
+.ng-invalid {
+  border: 1px red solid;
+}

--- a/www/js/controllers/historyCtrl.js
+++ b/www/js/controllers/historyCtrl.js
@@ -18,7 +18,7 @@ angular.module('Measure.controllers.History', [])
 		$scope.historicalDataChartConfig = historicalDataChartService.config;
 		$scope.shareCSV = SharingService.shareCSV;
 		$scope.hideMeasurement = HistoryService.hide;
-		$scope.retryUpload = function(idx){
+		$scope.retryUpload = function (idx) {
 			return HistoryService.retryUpload(idx);
 		}
 		/*
@@ -28,4 +28,30 @@ angular.module('Measure.controllers.History', [])
 		*/
 		$rootScope.$on('history:measurement:change', $scope.refreshData);
 		$scope.refreshData();
+
+		var footerTimeout = function () {
+			$timeout(function () {
+				$scope.uploadStatus = undefined;
+			}, 3000);
+		}
+
+		$rootScope.$on('upload:started', function () {
+			console.log("upload started");
+			$scope.uploadStatus = "started";
+			$scope.footerClass = "stable"
+			footerTimeout();
+		});
+
+		$rootScope.$on('upload:success', function () {
+			console.log("upload success");
+			$scope.uploadStatus = "success";
+			$scope.footerClass = "balanced";
+			footerTimeout();
+		});
+		$rootScope.$on('upload:failure', function () {
+			console.log("upload failure");
+			$scope.uploadStatus = "failure";
+			$scope.footerClass = "assertive";
+			footerTimeout();
+		});
 	});

--- a/www/js/controllers/historyCtrl.js
+++ b/www/js/controllers/historyCtrl.js
@@ -1,27 +1,32 @@
 angular.module('Measure.controllers.History', [])
 
-.controller('HistoryCtrl', function($scope, $rootScope, $interval, MeasureConfig, HistoryService,
-		SharingService, historicalDataChartService) {
+	.controller('HistoryCtrl', function ($scope, $rootScope, $interval, MeasureConfig, HistoryService,
+		SharingService, historicalDataChartService, UploadService) {
 
-	$scope.MeasureConfig = MeasureConfig;
-        $scope.series = [ "download", "upload" ];
-        $scope.data = { "series": "download" };
+		$scope.MeasureConfig = MeasureConfig;
+		$scope.series = ["download", "upload"];
+		$scope.data = { "series": "download" };
 
-        $scope.refreshData = function refreshData() {
-          historicalDataChartService.populateData($scope.data.series);
-          HistoryService.get().then(function(historicalData) {
-            $scope.historicalData = historicalData;
-          });
-        };
-        
-	$scope.historicalDataChartConfig = historicalDataChartService.config;
-	$scope.shareCSV = SharingService.shareCSV;
-	$scope.hideMeasurement = HistoryService.hide;
-	/*
-		Wait until after interface is draw to populate data for UX experience,
-		and then poll recentSamples to reflect changes as the user interacts
-		with the app.
-	*/
-	$rootScope.$on('history:measurement:change', $scope.refreshData);
-        $scope.refreshData();
-});
+		$scope.refreshData = function refreshData() {
+			console.log("Called refreshData");
+			historicalDataChartService.populateData($scope.data.series);
+			HistoryService.get().then(function (historicalData) {
+				$scope.historicalData = historicalData;
+			});
+		};
+
+		$scope.historicalDataChartConfig = historicalDataChartService.config;
+		$scope.shareCSV = SharingService.shareCSV;
+		$scope.hideMeasurement = HistoryService.hide;
+		$scope.retryUpload = function(idx){
+			return HistoryService.retryUpload(idx);
+		}
+		/*
+			Wait until after interface is draw to populate data for UX experience,
+			and then poll recentSamples to reflect changes as the user interacts
+			with the app.
+		*/
+		$rootScope.$on('history:measurement:change', $scope.refreshData);
+		$rootScope.$on('upload:failure', $scope.refreshData);
+		$scope.refreshData();
+	});

--- a/www/js/controllers/historyCtrl.js
+++ b/www/js/controllers/historyCtrl.js
@@ -27,6 +27,5 @@ angular.module('Measure.controllers.History', [])
 			with the app.
 		*/
 		$rootScope.$on('history:measurement:change', $scope.refreshData);
-		$rootScope.$on('upload:failure', $scope.refreshData);
 		$scope.refreshData();
 	});

--- a/www/js/controllers/historyCtrl.js
+++ b/www/js/controllers/historyCtrl.js
@@ -1,7 +1,7 @@
 angular.module('Measure.controllers.History', [])
 
-	.controller('HistoryCtrl', function ($scope, $rootScope, $interval, MeasureConfig, HistoryService,
-		SharingService, historicalDataChartService, UploadService) {
+	.controller('HistoryCtrl', function ($scope, $rootScope, MeasureConfig, HistoryService,
+		SharingService, historicalDataChartService, $timeout) {
 
 		$scope.MeasureConfig = MeasureConfig;
 		$scope.series = ["download", "upload"];

--- a/www/js/controllers/measureCtrl.js
+++ b/www/js/controllers/measureCtrl.js
@@ -1,6 +1,6 @@
 angular.module('Measure.controllers.Measurement', [])
 
-.controller('MeasureCtrl', function($scope, $q, $interval, $ionicPopup, $ionicLoading, SettingsService, $rootScope, StorageService, ChromeAppSupport, MLabService, accessInformation, HistoryService, DialogueMessages, MeasureConfig, connectionInformation) {
+.controller('MeasureCtrl', function($scope, $q, $interval, $ionicPopup, $ionicLoading, $timeout, SettingsService, $rootScope, StorageService, ChromeAppSupport, MLabService, accessInformation, HistoryService, DialogueMessages, MeasureConfig, connectionInformation) {
 
   $scope.currentState = undefined;
   $scope.currentRate = undefined;
@@ -129,6 +129,32 @@ angular.module('Measure.controllers.Measurement', [])
   $scope.startNDT = function() {
     ChromeAppSupport.notify('measurement:start');
     $scope.currentState = 'Starting';
+    $scope.uploadStatus = undefined;
   };
-});
 
+  var footerTimeout = function() {
+    $timeout(function() {
+      $scope.uploadStatus = undefined;
+    }, 2000);
+  }
+
+  $rootScope.$on('upload:started', function() {
+    chrome.runtime.sendMessage("upload started");
+    $scope.uploadStatus = "started";
+    $scope.footerClass = "stable"
+    footerTimeout();
+  });
+
+  $rootScope.$on('upload:success', function() {
+    chrome.runtime.sendMessage("upload success");
+    $scope.uploadStatus = "success";
+    $scope.footerClass = "balanced";
+    footerTimeout();
+  });
+  $rootScope.$on('upload:failure', function() {
+    chrome.runtime.sendMessage("upload failure");
+    $scope.uploadStatus = "failure";
+    $scope.footerClass = "assertive";
+    footerTimeout();
+  });
+});

--- a/www/js/controllers/measureCtrl.js
+++ b/www/js/controllers/measureCtrl.js
@@ -135,7 +135,7 @@ angular.module('Measure.controllers.Measurement', [])
   var footerTimeout = function() {
     $timeout(function() {
       $scope.uploadStatus = undefined;
-    }, 2000);
+    }, 3000);
   }
 
   $rootScope.$on('upload:started', function() {

--- a/www/js/controllers/measureCtrl.js
+++ b/www/js/controllers/measureCtrl.js
@@ -139,20 +139,20 @@ angular.module('Measure.controllers.Measurement', [])
   }
 
   $rootScope.$on('upload:started', function() {
-    chrome.runtime.sendMessage("upload started");
+    console.log("upload started");
     $scope.uploadStatus = "started";
     $scope.footerClass = "stable"
     footerTimeout();
   });
 
   $rootScope.$on('upload:success', function() {
-    chrome.runtime.sendMessage("upload success");
+    console.log("upload success");
     $scope.uploadStatus = "success";
     $scope.footerClass = "balanced";
     footerTimeout();
   });
   $rootScope.$on('upload:failure', function() {
-    chrome.runtime.sendMessage("upload failure");
+    console.log("upload failure");
     $scope.uploadStatus = "failure";
     $scope.footerClass = "assertive";
     footerTimeout();

--- a/www/js/controllers/settingsCtrl.js
+++ b/www/js/controllers/settingsCtrl.js
@@ -86,7 +86,7 @@ angular.module('Measure.controllers.Settings', [])
     return metroSelection.metro === 'automatic' ? 0 : metroSelection;
   };
 })
-.controller('UploadSettingsCtrl', function($scope, $ionicLoading, $http, SettingsService, UploadService) {
+.controller('UploadSettingsCtrl', function($scope, SettingsService) {
   $scope.availableSettings = SettingsService.availableSettings;
   $scope.currentSettings = SettingsService.currentSettings;
 
@@ -95,6 +95,11 @@ angular.module('Measure.controllers.Settings', [])
   };
 
   $scope.onChange = function(key, value) {
+    console.log($scope);
+    if ($scope.form.$invalid) {
+      return;
+    }
+
     SettingsService.setSetting(key, value);
   };
 })

--- a/www/js/controllers/settingsCtrl.js
+++ b/www/js/controllers/settingsCtrl.js
@@ -94,12 +94,17 @@ angular.module('Measure.controllers.Settings', [])
     SettingsService.setSetting("uploadEnabled", $scope.currentSettings.uploadEnabled);
   };
 
-  $scope.onChange = function(key, value) {
-    console.log($scope);
-    if ($scope.form.$invalid) {
-      return;
-    }
+  // function to submit the form after all validation has occurred
+  $scope.submitForm = function(isValid) {
 
-    SettingsService.setSetting(key, value);
+    // check to make sure the form is completely valid
+    if (isValid) {
+      SettingsService.setSetting("uploadURL", $scope.currentSettings.uploadURL);
+      SettingsService.setSetting("uploadAPIKey", $scope.currentSettings.uploadAPIKey);
+      SettingsService.setSetting("browserID", $scope.currentSettings.browserID);
+      SettingsService.setSetting("deviceType", $scope.currentSettings.deviceType);
+      SettingsService.setSetting("notes", $scope.currentSettings.notes);
+    }
   };
+
 })

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -53,7 +53,8 @@ angular.module('Measure.services.MeasurementClient', [])
       var measurementRecord = {
         'timestamp': Date.now(),
         'results': {},
-        'snapLog': {'s2cRate': [], 'c2sRate': []}
+        'snapLog': {'s2cRate': [], 'c2sRate': []},
+        'uploaded': false
       };
       var progress = 0;
 
@@ -72,7 +73,6 @@ angular.module('Measure.services.MeasurementClient', [])
             'passedResults': passedResults
           });
           measurementRecord.results = passedResults;
-          HistoryService.add(measurementRecord);
 
           // Send data to a measure-saver instance.
           SettingsService.get('uploadEnabled').then(function(enabled) {
@@ -81,11 +81,14 @@ angular.module('Measure.services.MeasurementClient', [])
               UploadService.uploadMeasurement(measurementRecord)
               .success(function(data) {
                 ChromeAppSupport.notify('upload:success', data);
+                measurementRecord.uploaded = true;
               })
               .error(function(data, status) {
                 ChromeAppSupport.notify('upload:failure', { "status": status, "data": data })
               });
             }
+
+            HistoryService.add(measurementRecord);
           });
         },
         function () {

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -82,13 +82,16 @@ angular.module('Measure.services.MeasurementClient', [])
               .success(function(data) {
                 ChromeAppSupport.notify('upload:success', data);
                 measurementRecord.uploaded = true;
+                console.log("Calling HistoryService.add")
+                HistoryService.add(measurementRecord);
               })
               .error(function(data, status) {
                 ChromeAppSupport.notify('upload:failure', { "status": status, "data": data })
-              });
+                HistoryService.add(measurementRecord);
+              })
+            } else {
+              HistoryService.add(measurementRecord);
             }
-
-            HistoryService.add(measurementRecord);
           });
         },
         function () {

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -1,7 +1,7 @@
 angular.module('Measure.services.MeasurementClient', [])
 
 .factory('MeasurementClientService', function($q, MeasurementService,
-  HistoryService, SettingsService, MLabService, accessInformation, $rootScope,
+  HistoryService, SettingsService, MLabService, accessInformation,
   ChromeAppSupport, UploadService) {
 
   function incrementProgress(current, state) {
@@ -73,6 +73,7 @@ angular.module('Measure.services.MeasurementClient', [])
             'passedResults': passedResults
           });
           measurementRecord.results = passedResults;
+          measurementRecord.uuid = passedResults["NDTResult.S2C.UUID"];
 
           // Send data to a measure-saver instance.
           SettingsService.get('uploadEnabled').then(function(enabled) {

--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -77,6 +77,7 @@ angular.module('Measure.services.MeasurementClient', [])
           // Send data to a measure-saver instance.
           SettingsService.get('uploadEnabled').then(function(enabled) {
             if (enabled) {
+              ChromeAppSupport.notify('upload:started', measurementRecord);
               UploadService.uploadMeasurement(measurementRecord)
               .success(function(data) {
                 ChromeAppSupport.notify('upload:success', data);

--- a/www/js/services/historyService.js
+++ b/www/js/services/historyService.js
@@ -14,9 +14,11 @@ angular.module('Measure.services.History', [])
   };
 
   HistoryService.add = function (measurementRecord) {
+    console.log("Adding measurement:" + measurementRecord);
     return HistoryService.get().then(function(historicalData) {
       measurementRecord.index = historicalData.measurements.length; // surrogate key, "good nuff" for now
       historicalData.measurements.push(measurementRecord);
+      $rootScope.$emit('history:measurement:change');
       return historicalData;
     })
     .then(set)
@@ -55,15 +57,15 @@ angular.module('Measure.services.History', [])
     return HistoryService.get().then(function (historicalData) {
       historicalData.measurements.some(function (measurement) {
         if (measurement.index == index) {
-          console.log("Trying to upload measurement with index: " + index);
+          $rootScope.$broadcast('upload:started', index);
           UploadService.uploadMeasurement(measurement)
             .success(function (data) {
               console.log("Success, setting uploaded = true");
-              ChromeAppSupport.notify('upload:success', data);
+              $rootScope.$broadcast('upload:success', data);
               measurement.uploaded = true;
             })
             .error(function (data, status) {
-              ChromeAppSupport.notify('upload:failure', { "status": status, "data": data })
+              $rootScope.$broadcast('upload:failure', { "status": status, "data": data })
             }).then(function() {
               set(historicalData);
             }).then(function() {

--- a/www/js/services/historyService.js
+++ b/www/js/services/historyService.js
@@ -30,10 +30,10 @@ angular.module('Measure.services.History', [])
           return measurement.index != index;
         });
       }
+      set(historicalData)
+      console.log("Broadcast history change"); $rootScope.$emit('history:measurement:change', index);
       return historicalData;
-    })
-    .then(set)
-    .then(function() { ChromeAppSupport.notify('history:measurement:change', index); });
+    });
   };
 
   HistoryService.annonate = function (index, measurementNote) {

--- a/www/js/services/settingsService.js
+++ b/www/js/services/settingsService.js
@@ -59,6 +59,10 @@ angular.module('Measure.services.Settings', [])
     'deviceType': {
       'default': '',
       'type': 'string',
+    },
+    'notes': {
+      'default': '',
+      'type': 'string',
     }
   };
 

--- a/www/js/services/settingsService.js
+++ b/www/js/services/settingsService.js
@@ -48,7 +48,7 @@ angular.module('Measure.services.Settings', [])
       'default': '',
       'type': 'string',
     },
-    'uploadApiKey': {
+    'uploadAPIKey': {
       'default': '',
       'type': 'string',
     },

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -12,8 +12,10 @@ angular.module('Measure.services.Upload', [])
         }
 
         uploadURL = settings.uploadURL;
+        apiKey = settings.uploadAPIKey;
         browserID = settings.browserID;
         deviceType = settings.deviceType;
+        notes = settings.notes;
 
         // Generate a valid Measurement message for measure-saver.
         var measurement = {
@@ -61,6 +63,10 @@ angular.module('Measure.services.Upload', [])
             measurement.ServerInfo.URL = serverInfo.url;
         }
 
+        // Add API key if configured.
+        if (apiKey != "") {
+            uploadURL = uploadURL + "&api=" + apiKey;
+        }
         return $http.post(uploadURL, measurement);
     };
 

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -16,8 +16,11 @@ angular.module('Measure.services.Upload', [])
             notes = SettingsService.currentSettings.notes;
 
             // Generate a valid Measurement message for measure-saver.
+            ts = new Date(record.timestamp);
             var measurement = {
+                "UUID": record.uuid,
                 "BrowserID": browserID,
+                "Timestamp": ts.toISOString(),
                 "DeviceType": deviceType,
                 "Notes": notes,
                 "Download": record.results.s2cRate,

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -1,74 +1,73 @@
 angular.module('Measure.services.Upload', [])
-.factory('UploadService', function ($q, $http, SettingsService) {
-    var UploadService = {};
+    .factory('UploadService', function ($q, $http, SettingsService) {
+        var UploadService = {};
 
-    UploadService.uploadMeasurement = function(record) {
-        var settings = SettingsService.currentSettings;
+        UploadService.uploadMeasurement = function (record) {
+            // This function should never be called if the upload feature is not
+            // enabled in the extension's settings.
+            if (!SettingsService.currentSettings.uploadEnabled) {
+                return;
+            }
 
-        // This function should never be called if the upload feature is not
-        // enabled in the extension's settings.
-        if (!settings.uploadEnabled) {
-            return;
-        }
+            uploadURL = SettingsService.currentSettings.uploadURL;
+            apiKey = SettingsService.currentSettings.uploadAPIKey;
+            browserID = SettingsService.currentSettings.browserID;
+            deviceType = SettingsService.currentSettings.deviceType;
+            notes = SettingsService.currentSettings.notes;
 
-        uploadURL = settings.uploadURL;
-        apiKey = settings.uploadAPIKey;
-        browserID = settings.browserID;
-        deviceType = settings.deviceType;
-        notes = settings.notes;
+            // Generate a valid Measurement message for measure-saver.
+            var measurement = {
+                "BrowserID": browserID,
+                "DeviceType": deviceType,
+                "Notes": notes,
+                "Download": record.results.s2cRate,
+                "Upload": record.results.c2sRate,
+                "Latency": parseInt(record.results.MinRTT),
+                "Results": record.results
+            };
 
-        // Generate a valid Measurement message for measure-saver.
-        var measurement = {
-            "BrowserID": browserID,
-            "DeviceType": deviceType,
-            "Download": record.results.s2cRate,
-            "Upload": record.results.c2sRate,
-            "Latency": parseInt(record.results.MinRTT),
-            "Results": record.results,
+            if (record.hasOwnProperty("accessInformation")) {
+                // If we've got client data from ipinfo, add it to the Measurement
+                // object.
+                var clientInfo = record.accessInformation;
+                measurement.ClientInfo = {}
+                measurement.ClientInfo.ASN = clientInfo.asn;
+                measurement.ClientInfo.City = clientInfo.city;
+                measurement.ClientInfo.Country = clientInfo.country;
+                measurement.ClientInfo.Hostname = clientInfo.hostname;
+                measurement.ClientInfo.IP = clientInfo.ip;
+                var coords = clientInfo.loc.split(",");
+                if (coords.length == 2) {
+                    measurement.ClientInfo.Latitude = parseFloat(coords[0]);
+                    measurement.ClientInfo.Longitude = parseFloat(coords[1]);
+                }
+                measurement.ClientInfo.ISP = clientInfo.org;
+                measurement.ClientInfo.Postal = clientInfo.postal;
+                measurement.ClientInfo.Region = clientInfo.region;
+                measurement.ClientInfo.Timezone = clientInfo.timezone;
+            }
+            if (record.hasOwnProperty("mlabInformation")) {
+                // If we've got server data from mlab-ns, add it to the Measurement
+                // object.
+                var serverInfo = record.mlabInformation;
+                measurement.ServerInfo = {}
+                measurement.ServerInfo.FQDN = serverInfo.fqdn;
+                measurement.ServerInfo.IPv4 = serverInfo.ip[0];
+                measurement.ServerInfo.IPv6 = serverInfo.ip[1];
+                measurement.ServerInfo.City = serverInfo.city;
+                measurement.ServerInfo.Country = serverInfo.country;
+                measurement.ServerInfo.Label = serverInfo.label;
+                measurement.ServerInfo.Metro = serverInfo.metro;
+                measurement.ServerInfo.Site = serverInfo.site;
+                measurement.ServerInfo.URL = serverInfo.url;
+            }
+
+            // Add API key if configured.
+            if (apiKey != "") {
+                uploadURL = uploadURL + "?key=" + apiKey;
+            }
+            return $http.post(uploadURL, measurement);
         };
 
-        if (record.hasOwnProperty("accessInformation")) {
-            // If we've got client data from ipinfo, add it to the Measurement
-            // object.
-            var clientInfo = record.accessInformation;
-            measurement.ClientInfo = {}
-            measurement.ClientInfo.ASN = clientInfo.asn;
-            measurement.ClientInfo.City = clientInfo.city;
-            measurement.ClientInfo.Country = clientInfo.country;
-            measurement.ClientInfo.Hostname = clientInfo.hostname;
-            measurement.ClientInfo.IP = clientInfo.ip;
-            var coords = clientInfo.loc.split(",");
-            if (coords.length == 2) {
-                measurement.ClientInfo.Latitude = parseFloat(coords[0]);
-                measurement.ClientInfo.Longitude = parseFloat(coords[1]);
-            }
-            measurement.ClientInfo.ISP = clientInfo.org;
-            measurement.ClientInfo.Postal = clientInfo.postal;
-            measurement.ClientInfo.Region = clientInfo.region;
-            measurement.ClientInfo.Timezone = clientInfo.timezone;
-        }
-        if (record.hasOwnProperty("mlabInformation")) {
-            // If we've got server data from mlab-ns, add it to the Measurement
-            // object.
-            var serverInfo = record.mlabInformation;
-            measurement.ServerInfo = {}
-            measurement.ServerInfo.FQDN = serverInfo.fqdn;
-            measurement.ServerInfo.IPv4 = serverInfo.ip[0];
-            measurement.ServerInfo.IPv6 = serverInfo.ip[1];
-            measurement.ServerInfo.City = serverInfo.city;
-            measurement.ServerInfo.Country = serverInfo.country;
-            measurement.ServerInfo.Label = serverInfo.label;
-            measurement.ServerInfo.Metro = serverInfo.metro;
-            measurement.ServerInfo.Site = serverInfo.site;
-            measurement.ServerInfo.URL = serverInfo.url;
-        }
-
-        // Add API key if configured.
-        if (apiKey != "") {
-            uploadURL = uploadURL + "&api=" + apiKey;
-        }
-        return $http.post(uploadURL, measurement);
-    };
-
-    return UploadService;
-});
+        return UploadService;
+    });

--- a/www/js/support/chromeApp/appBackground.js
+++ b/www/js/support/chromeApp/appBackground.js
@@ -79,4 +79,3 @@ angular.element(document).ready(function () {
   angular.bootstrap(document, ['Measure']);
   console.log("Bootstrapped Measure module");
 });
-

--- a/www/templates/history.html
+++ b/www/templates/history.html
@@ -1,36 +1,35 @@
 <ion-view view-title="{{ 'Explore Data' | translate }}">
-    <ion-nav-buttons side="secondary">
-      <button class="button" aria-label="Export to CSV"
-            on-tap="shareCSV(historicalData.measurements)"
+	<ion-nav-buttons side="secondary">
+		<button class="button" aria-label="Export to CSV" on-tap="shareCSV(historicalData.measurements)"
 			translate>Export</button>
 	</ion-nav-buttons>
-        <div ng-if="historicalData.measurements.length === 0">
-	<ion-content class="panel__history__empty">
-		<div class="row">
-			<div class="col col-offset-25 col-50 center emptyIcon"><i class="ion-erlenmeyer-flask"></i></div>
-		</div>
-		<div class="row">
-			<div class="col col-offset-25 col-50 center">No measurements yet. When you conduct tests, they will fill in here.</div>
-		</div>
-	</ion-content>
-        </div>
-        <div ng-if="historicalData.measurements.length > 0">
-	<ion-content class="panel__history">
-			<highchart id="historicalDataChart" config="historicalDataChartConfig" class="historicalDataChart"></highchart>
+	<div ng-if="historicalData.measurements.length === 0">
+		<ion-content class="panel__history__empty">
+			<div class="row">
+				<div class="col col-offset-25 col-50 center emptyIcon"><i class="ion-erlenmeyer-flask"></i></div>
+			</div>
+			<div class="row">
+				<div class="col col-offset-25 col-50 center">No measurements yet. When you conduct tests, they will fill
+					in here.</div>
+			</div>
+		</ion-content>
+	</div>
+	<div ng-if="historicalData.measurements.length > 0">
+		<ion-content class="panel__history">
+			<highchart id="historicalDataChart" config="historicalDataChartConfig" class="historicalDataChart">
+			</highchart>
 			<ion-list show-delete="false" can-swipe="true">
-                        <label class="item item-input item-select">
-                          <div class="input-label" translate>Statistic</div>
-                          <select ng-model="data.series"
-                                  ng-change="refreshData()"
-                                  ng-options="stat as (stat | capitalize:true | translate) for stat in series">
-                          </select>
-                        </label>
-                                <div class="item item-divider">
+				<label class="item item-input item-select">
+					<div class="input-label" translate>Statistic</div>
+					<select ng-model="data.series" ng-change="refreshData()"
+						ng-options="stat as (stat | capitalize:true | translate) for stat in series">
+					</select>
+				</label>
+				<div class="item item-divider">
 					<span translate>Measurement History</span>
 					<span class="badge badge-assertive">{{ historicalData.measurements.length }} </span>
 				</div>
-				<ion-item
-                                          ng-repeat="measurementRecord in historicalData.measurements | orderBy:'timestamp':true" >
+				<ion-item ng-repeat="measurementRecord in historicalData.measurements | orderBy:'timestamp':true">
 					<div class="row" ng-if="measurementRecord.accessInformation !== undefined">
 						<div class="col">
 							<h2>{{ measurementRecord.accessInformation.org }}</h2>
@@ -73,23 +72,32 @@
 						</div>
 						<div class="col right" ng-show="!measurementRecord.uploaded">
 							<small>
-							<i class="icon ion-close-circled"></i> No
+								<i class="icon ion-close-circled"></i> No
 							</small>
 						</div>
 					</div>
-					<ion-option-button class="button-light icon ion-heart"
-							ng-if="MeasureConfig.sharingSupported"
-							ng-click="shareMeasurement()">
-							</ion-option-button>
-					<ion-option-button class="button-light icon ion-upload"
-							ng-if="!measurementRecord.uploaded"
-							ng-click="retryUpload(measurementRecord.index)">
-							</ion-option-button>
+					<ion-option-button class="button-light icon ion-heart" ng-if="MeasureConfig.sharingSupported"
+						ng-click="shareMeasurement()">
+					</ion-option-button>
+					<ion-option-button class="button-light icon ion-upload" ng-if="!measurementRecord.uploaded"
+						ng-click="retryUpload(measurementRecord.index)">
+					</ion-option-button>
 					<ion-option-button class="button-assertive icon ion-trash-a"
-							ng-click="hideMeasurement(measurementRecord.index)">
-							</ion-option-button>
+						ng-click="hideMeasurement(measurementRecord.index)">
+					</ion-option-button>
 				</ion-item>
 			</ion-list>
-	</ion-content>
-        </div>
+		</ion-content>
+	</div>
+	<div class="bar bar-footer" ng-class="'bar-' + footerClass" ng-show="uploadStatus !== undefined">
+		<div class="title" ng-show="uploadStatus == 'success'"">
+			<span translate>Upload successful!</span>
+		</div>
+		<div class="title" ng-show="uploadStatus == 'failure'"">
+			<span translate>Upload failed, please check settings</span>
+		</div>
+		<div class="title" ng-show="uploadStatus == 'started'"">
+			<span translate>Uploading results...</span>
+		</div>
+	</div>
 </ion-view>

--- a/www/templates/history.html
+++ b/www/templates/history.html
@@ -29,7 +29,7 @@
 					<span translate>Measurement History</span>
 					<span class="badge badge-assertive">{{ historicalData.measurements.length }} </span>
 				</div>
-				<ion-item ui-sref="app.measurementRecord({measurementId: measurementRecord.index})"
+				<ion-item
                                           ng-repeat="measurementRecord in historicalData.measurements | orderBy:'timestamp':true" >
 					<div class="row" ng-if="measurementRecord.accessInformation !== undefined">
 						<div class="col">
@@ -62,9 +62,28 @@
 							<small>{{ measurementRecord.results.MinRTT | formatLatencyMeasurement }}</small>
 						</div>
 					</div>
+					<div class="row">
+						<div class="col">
+							<small class="label" translate>Uploaded</small>
+						</div>
+						<div class="col right" ng-show="measurementRecord.uploaded">
+							<small>
+								<i class="icon ion-checkmark-circled"></i> Yes
+							</small>
+						</div>
+						<div class="col right" ng-show="!measurementRecord.uploaded">
+							<small>
+							<i class="icon ion-close-circled"></i> No
+							</small>
+						</div>
+					</div>
 					<ion-option-button class="button-light icon ion-heart"
 							ng-if="MeasureConfig.sharingSupported"
 							ng-click="shareMeasurement()">
+							</ion-option-button>
+					<ion-option-button class="button-light icon ion-upload"
+							ng-if="!measurementRecord.uploaded"
+							ng-click="retryUpload(measurementRecord.index)">
 							</ion-option-button>
 					<ion-option-button class="button-assertive icon ion-trash-a"
 							ng-click="hideMeasurement(measurementRecord.index)">

--- a/www/templates/measure.html
+++ b/www/templates/measure.html
@@ -6,7 +6,7 @@
 		</ion-nav-buttons>
 	</ion-nav-bar>
 	<ion-content class="panel__measure" padding="false">
-        <div class="row padding-vertical">
+        <div class="row">
 			<div class="col center">
 				<i class="icon ion-earth" ng-show="!mlabInformation.label"></i>
 				<a ui-sref="app.serverSelection()" ng-show="mlabInformation.label"
@@ -14,7 +14,7 @@
                                   ng-bind="mlabInformation.label"></a>
 			</div>
         </div>
-        <div class="row padding-vertical">
+        <div class="row">
 			<div class="col center">
 				<i class="icon ion-cloud currentNetwork" ng-show="!accessInformation.org"></i>
 				<span class="currentNetwork" ng-bind="accessInformation.org"></span>
@@ -69,4 +69,15 @@
 			</div>
 		</div>
 	</ion-content>
+	<div class="bar bar-footer" ng-class="'bar-' + footerClass" ng-show="uploadStatus !== undefined">
+		<div class="title" ng-show="uploadStatus == 'success'"">
+			<span translate>Upload successful!</span>
+		</div>
+		<div class="title" ng-show="uploadStatus == 'failure'"">
+			<span translate>Upload failed, please check settings</span>
+		</div>
+		<div class="title" ng-show="uploadStatus == 'started'"">
+			<span translate>Uploading results...</span>
+		</div>
+	</div>
 </ion-view>

--- a/www/templates/settings.html
+++ b/www/templates/settings.html
@@ -6,7 +6,7 @@
     <i class="icon ion-chevron-right"></i>
   </a>
   <a class="item item-icon-right" ui-sref="app.uploadSettings()" >
-    <span translate>Upload</span>
+    <span translate>Upload Results</span>
     <i class="icon ion-chevron-right"></i>
   </a>
   <!-- -->

--- a/www/templates/uploadSettings.html
+++ b/www/templates/uploadSettings.html
@@ -1,33 +1,37 @@
 <ion-view view-title="{{ 'Upload settings' | translate }}">
   <ion-content>
+    <form name="form" novalidate>
+      <ion-toggle ng-model="currentSettings.uploadEnabled" ng-change="setUploadEnabled()">
+        <span translate>Upload measurements</span>
+      </ion-toggle>
 
-    <ion-toggle ng-model="currentSettings.uploadEnabled" ng-change="setUploadEnabled()">
-      <span translate>Upload measurements</span>
-    </ion-toggle>
+      <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+        <span class="input-label">Server URL</span>
+        <input required name="url" type="url" ng-model="currentSettings.uploadURL"
+          ng-change="onChange('uploadURL', currentSettings.uploadURL)"></input>
+        <p ng-show="form.url.$invalid && !form.url.$pristine" class="help-block">Please provide a valid URL.</p>
+      </label>
 
-    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
-      <span class="input-label">Server URL</span>
-      <input type="text" ng-model="currentSettings.uploadURL"
-        ng-change="onChange('uploadURL', currentSettings.uploadURL)"></input>
-    </label>
+      <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+        <span class="input-label">API key</span>
+        <input required name="key" type="text" ng-model="currentSettings.uploadAPIKey"
+          ng-change="onChange('uploadAPIKey', currentSettings.uploadAPIKey)"></input>
+        <p ng-show="form.url.$invalid && !form.url.$pristine" class="help-block">An API key is required.</p>
+      </label>
 
-    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
-      <span class="input-label">API key</span>
-      <input type="text" ng-model="currentSettings.uploadAPIKey"
-        ng-change="onChange('uploadAPIKey', currentSettings.uploadAPIKey)"></input>
-    </label>
+      <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+        <span class="input-label">Browser ID</span>
+        <input required name="browserid" type="text" ng-model="currentSettings.browserID"
+          ng-change="onChange('browserID', currentSettings.browserID)"></input>
+        <p ng-show="form.browserid.$invalid && !form.browserid.$pristine" class="help-block">A browser ID is required.
+        </p>
+      </label>
 
-    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
-      <span class="input-label">Browser ID</span>
-      <input type="text" ng-model="currentSettings.browserID"
-        ng-change="onChange('browserID', currentSettings.browserID)"></input>
-    </label>
-
-    <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
-      <span class="input-label">Device type</span>
-      <input type="text" ng-model="currentSettings.deviceType"
-        ng-change="onChange('deviceType', currentSettings.deviceType)"></input>
-    </label>
-
+      <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+        <span class="input-label">Device type</span>
+        <input type="text" ng-model="currentSettings.deviceType"
+          ng-change="onChange('deviceType', currentSettings.deviceType)"></input>
+      </label>
+    </form>
   </ion-content>
 </ion-view>

--- a/www/templates/uploadSettings.html
+++ b/www/templates/uploadSettings.html
@@ -1,37 +1,49 @@
 <ion-view view-title="{{ 'Upload settings' | translate }}">
-  <ion-content>
-    <form name="form" novalidate>
+  <form name="uploadForm" ng-submit="submitForm(uploadForm.$valid); uploadForm.$setPristine()" novalidate>
+    <ion-content>
       <ion-toggle ng-model="currentSettings.uploadEnabled" ng-change="setUploadEnabled()">
         <span translate>Upload measurements</span>
       </ion-toggle>
 
       <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
         <span class="input-label">Server URL</span>
-        <input required name="url" type="url" ng-model="currentSettings.uploadURL"
-          ng-change="onChange('uploadURL', currentSettings.uploadURL)"></input>
-        <p ng-show="form.url.$invalid && !form.url.$pristine" class="help-block">Please provide a valid URL.</p>
+        <input required name="url" type="url" ng-model="currentSettings.uploadURL"></input>
+        <p ng-show="uploadForm.url.$invalid && uploadForm.url.$touched" class="help-block">Please provide a valid URL.
+        </p>
       </label>
 
       <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
         <span class="input-label">API key</span>
-        <input required name="key" type="text" ng-model="currentSettings.uploadAPIKey"
-          ng-change="onChange('uploadAPIKey', currentSettings.uploadAPIKey)"></input>
-        <p ng-show="form.url.$invalid && !form.url.$pristine" class="help-block">An API key is required.</p>
+        <input required name="key" type="text" ng-model="currentSettings.uploadAPIKey"></input>
+        <p ng-show="uploadForm.key.$invalid && uploadForm.key.$touched" class="help-block">An API key is required.</p>
       </label>
 
       <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
         <span class="input-label">Browser ID</span>
-        <input required name="browserid" type="text" ng-model="currentSettings.browserID"
-          ng-change="onChange('browserID', currentSettings.browserID)"></input>
-        <p ng-show="form.browserid.$invalid && !form.browserid.$pristine" class="help-block">A browser ID is required.
+        <input required name="browserid" type="text" ng-model="currentSettings.browserID"></input>
+        <p ng-show="uploadForm.browserid.$invalid && uploadForm.browserid.$touched" class="help-block">A browser ID is
+          required.
         </p>
       </label>
 
       <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
         <span class="input-label">Device type</span>
-        <input type="text" ng-model="currentSettings.deviceType"
-          ng-change="onChange('deviceType', currentSettings.deviceType)"></input>
+        <input type="text" ng-model="currentSettings.deviceType"></input>
       </label>
-    </form>
-  </ion-content>
+
+      <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
+        <span class="input-label">Notes</span>
+        <input type="text" ng-model="currentSettings.notes"></input>
+      </label>
+
+      </div>
+      </div>
+      <div class="row">
+        <div class="col col-center">
+          <button type="submit" ng-disabled="uploadForm.$invalid || uploadForm.$pristine" class="button button-block button-light button-balanced">Save</button>
+        </div>
+      </div>
+    </ion-content>
+  </form>
+
 </ion-view>

--- a/www/templates/uploadSettings.html
+++ b/www/templates/uploadSettings.html
@@ -2,7 +2,7 @@
   <form name="uploadForm" ng-submit="submitForm(uploadForm.$valid); uploadForm.$setPristine()" novalidate>
     <ion-content>
       <ion-toggle ng-model="currentSettings.uploadEnabled" ng-change="setUploadEnabled()">
-        <span translate>Upload measurements</span>
+        <span translate>Enable Uploading</span>
       </ion-toggle>
 
       <label class="item item-input item-stacked-label" ng-if="currentSettings.uploadEnabled">
@@ -40,7 +40,7 @@
       </div>
       <div class="row">
         <div class="col col-center">
-          <button type="submit" ng-disabled="uploadForm.$invalid || uploadForm.$pristine" class="button button-block button-light button-balanced">Save</button>
+          <button type="submit" ng-disabled="uploadForm.$invalid" class="button button-block button-light button-balanced">Save</button>
         </div>
       </div>
     </ion-content>


### PR DESCRIPTION
This PR makes quite a few changes to the extension:
- The Upload feature is now configurable via a new section in the Settings
- If the upload is enabled, it will attempt to upload the new measurement at the end of a test, displaying the result to the user
- If the upload has failed, it's possible to retry uploading old measurements from the "Explore Data" section, by opening the contextual menu on each entry (swiping to the left) and clicking the upload icon.