### PR TITLE
Update README.md with new build instructions + make linter happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,37 @@
 
 ## Development
 
-#### Prerequisites
+### Prerequisites
+
 * [Node v0.12+](https://nodejs.org)
-  - Preferably via [nvm](https://github.com/creationix/nvm), e.g. `nvm use [version]`
+  * Preferably via [nvm](https://github.com/creationix/nvm), e.g. `nvm use [version]`
 * [Cordova](https://www.npmjs.com/package/cordova), [Gulp](http://gulpjs.com), and [CCA](https://github.com/MobileChromeApps/mobile-chrome-apps) toolchain: `npm install -g cordova cca gulp-cli`
+* [Yarn](https://yarnpkg.com/): `npm install -g yarn`
 * [Android SDK](http://developer.android.com/sdk/installing/index.html?pkg=tools)
-  - To completely install the SDK, you must:
-  - run `[sdk directory]/tools/android sdk` and setup the [tools](http://developer.android.com/sdk/installing/adding-packages.html)
-  - Minimal packages that must be installed:
-    - Android SDK Tools
-    - Android Platform-tools
-    - Android SDK Build-tools **22.0.1**
-    - Android 5.1.1 (API 22) > SDK Platform (this may also require you to install higher SDK Platform versions)
-    - Extras > Android Support Repository
-    - Extras > Android Support Library
+  * To completely install the SDK, you must:
+  * run `[sdk directory]/tools/android sdk` and setup the [tools](http://developer.android.com/sdk/installing/adding-packages.html)
+  * Minimal packages that must be installed:
+    * Android SDK Tools
+    * Android Platform-tools
+    * Android SDK Build-tools **22.0.1**
+    * Android 5.1.1 (API 22) > SDK Platform (this may also require you to install higher SDK Platform versions)
+    * Extras > Android Support Repository
+    * Extras > Android Support Library
 
-  - Optionally, install a system image for the emulator.
+  * Optionally, install a system image for the emulator.
 
-#### Getting Started
+### Getting Started
 
 After installing prerequisites, run:
 
 ```bash
-# Setup build environment
-npm install
+# Install dependencies and set up build environment
+yarn
 ```
 
 ## Mobile App
 
-#### Building
+### Building as an Android App
 
 To build as an Android app:
 
@@ -43,7 +45,7 @@ cca prepare android
 cca build android
 ```
 
-#### Running
+### Running
 
 ```bash
 # Run on emulator
@@ -63,11 +65,11 @@ cca build android --release
 
 ## Chrome Extension
 
-#### Building
+### Building as a Chrome Extension
 
 **NB:** The app can be loaded as a Chrome App (standalone) or Chrome extension (browser-embedded).
 
-Only run this command if you want to build the extension version.  Otherwise skip to [Running](#running).
+Only run this command if you want to build the extension version.  Otherwise skip to [Running](#Running).
 
 ```bash
 gulp extension
@@ -99,7 +101,7 @@ This will create a `www.crx` and associated private key `www.pem`.  You'll need 
 To publish as a Chrome App, you'll need to:
 
 * Edit the version in `www/manifest.json` to be higher than the previous version, Note: 0.15 < 0.16 but 0.15 > 0.2
-* Zip up the `www` folder 
+* Zip up the `www` folder
 * Log into the Chrome Developers Console
 * Edit the existing application
 * Upload new version, and save to publish the app
@@ -110,12 +112,14 @@ To publish as a Chrome App, you'll need to:
 
 User interface strings are tagged in the source code using the [getttext](https://en.wikipedia.org/wiki/Gettext) system. Strings presented in the application's user interface are coded with _gettext_ function calls, for example:
 
-```
+```html
 # Examples from an HTML template:
 
 <ion-view view-title="{{ 'About' | translate }}">
 <span translate>About M-Lab Measure App</span>
+```
 
+```javascript
 # Examples from a JS file:
 
 .controller("manualTranslationStrings", function (gettext) {


### PR DESCRIPTION
This PR updates the README with the instructions to use Yarn instead of npm.

It also fixes several markdown-related linter warnings.