### PR TITLE
Add client.application metadata

### DIFF
--- a/www/js/measurements/ndt/ndt-browser-client.js
+++ b/www/js/measurements/ndt/ndt-browser-client.js
@@ -447,6 +447,8 @@ NDTjs.prototype.ndtMetaTest = function (ndtSocket) {
       // Send one piece of meta data and then an empty meta data packet
       ndtSocket.send(that.makeNdtMessage(that.TEST_MSG,
                                          'client.os.name:NDTjs'));
+      ndtSocket.send(that.makeNdtMessage(that.TEST_MSG,
+                              'client.application:measure-chrome-extension'));
       ndtSocket.send(that.makeNdtMessage(that.TEST_MSG, ''));
       state = 'WAIT_FOR_TEST_FINALIZE';
       return false;


### PR DESCRIPTION
This PR makes the NDTjs client send the `client.application` field with value `measure-chrome-extension`. This should make tests coming from the Chrome Extension easily filterable in BigQuery later.

This has been hardcoded in the local copy of the NDTjs client since there is no way to pass the `client.application` field at the moment. Updating the client itself (in the ndt-server repository) would break its API for other users.