### PR TITLE
Hide Upload button on old measurements

### DIFF
--- a/www/js/controllers/historyCtrl.js
+++ b/www/js/controllers/historyCtrl.js
@@ -1,8 +1,9 @@
 angular.module('Measure.controllers.History', [])
 
 	.controller('HistoryCtrl', function ($scope, $rootScope, MeasureConfig, HistoryService,
-		SharingService, historicalDataChartService, $timeout) {
+		SharingService, historicalDataChartService, $timeout, SettingsService) {
 
+		$scope.currentSettings = SettingsService.currentSettings;
 		$scope.MeasureConfig = MeasureConfig;
 		$scope.series = ["download", "upload"];
 		$scope.data = { "series": "download" };

--- a/www/templates/history.html
+++ b/www/templates/history.html
@@ -79,7 +79,8 @@
 					<ion-option-button class="button-light icon ion-heart" ng-if="MeasureConfig.sharingSupported"
 						ng-click="shareMeasurement()">
 					</ion-option-button>
-					<ion-option-button class="button-light icon ion-upload" ng-if="measurementRecord.uploaded == false"
+					<ion-option-button class="button-light icon ion-upload"
+						ng-if="measurementRecord.uploaded == false && currentSettings.uploadEnabled"
 						ng-click="retryUpload(measurementRecord.index)">
 					</ion-option-button>
 					<ion-option-button class="button-assertive icon ion-trash-a"

--- a/www/templates/history.html
+++ b/www/templates/history.html
@@ -79,7 +79,7 @@
 					<ion-option-button class="button-light icon ion-heart" ng-if="MeasureConfig.sharingSupported"
 						ng-click="shareMeasurement()">
 					</ion-option-button>
-					<ion-option-button class="button-light icon ion-upload" ng-if="!measurementRecord.uploaded"
+					<ion-option-button class="button-light icon ion-upload" ng-if="measurementRecord.uploaded == false"
 						ng-click="retryUpload(measurementRecord.index)">
 					</ion-option-button>
 					<ion-option-button class="button-assertive icon ion-trash-a"


### PR DESCRIPTION
This PR hides the "Upload" button on Measurements that were recorded with an older version of this extension. The button is also hidden if the upload feature is disabled entirely. 