### PR TITLE
Fix CSV export.

### DIFF
--- a/www/js/services/clientService.js
+++ b/www/js/services/clientService.js
@@ -75,6 +75,10 @@ angular.module('Measure.services.MeasurementClient', [])
           measurementRecord.results = passedResults;
           measurementRecord.uuid = passedResults["NDTResult.S2C.UUID"];
 
+          // Set MeasurementRecord's version. Data recorded by older code won't
+          // have this field.
+          measurementRecord.version = 1;
+
           // Send data to a measure-saver instance.
           SettingsService.get('uploadEnabled').then(function(enabled) {
             if (enabled) {

--- a/www/js/services/sharingService.js
+++ b/www/js/services/sharingService.js
@@ -1,5 +1,5 @@
 angular.module('Measure.services.Sharing', [])
-.factory('SharingService', function($timeout, SettingsService) {
+.factory('SharingService', function($timeout, SettingsService, UploadService) {
   var SharingService = {};
 
   SharingService.shareCSV = function (dataContent) {
@@ -19,60 +19,8 @@ angular.module('Measure.services.Sharing', [])
       { "key": "accessInformation.longitude", "fn": function(input) { return parseFloatSafe(input["accessInformation.longitude"], input["accessInformation.longitude"]).toFixed(4); } },
     ];
 
-    uploadURL = SettingsService.currentSettings.uploadURL;
-    browserID = SettingsService.currentSettings.browserID;
-    deviceType = SettingsService.currentSettings.deviceType;
-    notes = SettingsService.currentSettings.notes;
-
     var csvContents = dataContent.map(function (record) {
-      var measurement = {
-        "UUID": record.uuid,
-        "BrowserID": browserID,
-        "DeviceType": deviceType,
-        "Notes": notes,
-        "Download": record.results.s2cRate,
-        "Upload": record.results.c2sRate,
-        "Latency": parseInt(record.results.MinRTT),
-        "Results": record.results
-      };
-
-      if (record.hasOwnProperty("accessInformation")) {
-          // If we've got client data from ipinfo, add it to the Measurement
-          // object.
-          var clientInfo = record.accessInformation;
-          measurement.ClientInfo = {}
-          measurement.ClientInfo.ASN = clientInfo.asn;
-          measurement.ClientInfo.City = clientInfo.city;
-          measurement.ClientInfo.Country = clientInfo.country;
-          measurement.ClientInfo.Hostname = clientInfo.hostname;
-          measurement.ClientInfo.IP = clientInfo.ip;
-          var coords = clientInfo.loc.split(",");
-          if (coords.length == 2) {
-              measurement.ClientInfo.Latitude = parseFloat(coords[0]);
-              measurement.ClientInfo.Longitude = parseFloat(coords[1]);
-          }
-          measurement.ClientInfo.ISP = clientInfo.org;
-          measurement.ClientInfo.Postal = clientInfo.postal;
-          measurement.ClientInfo.Region = clientInfo.region;
-          measurement.ClientInfo.Timezone = clientInfo.timezone;
-      }
-      if (record.hasOwnProperty("mlabInformation")) {
-          // If we've got server data from mlab-ns, add it to the Measurement
-          // object.
-          var serverInfo = record.mlabInformation;
-          measurement.ServerInfo = {}
-          measurement.ServerInfo.FQDN = serverInfo.fqdn;
-          measurement.ServerInfo.IPv4 = serverInfo.ip[0];
-          measurement.ServerInfo.IPv6 = serverInfo.ip[1];
-          measurement.ServerInfo.City = serverInfo.city;
-          measurement.ServerInfo.Country = serverInfo.country;
-          measurement.ServerInfo.Label = serverInfo.label;
-          measurement.ServerInfo.Metro = serverInfo.metro;
-          measurement.ServerInfo.Site = serverInfo.site;
-          measurement.ServerInfo.URL = serverInfo.url;
-      }
-
-      return flatten(measurement);
+      return flatten(UploadService.makeMeasurement(record));
     });
 
     var csvHeaders = Object.keys(csvContents[0]);

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -11,7 +11,8 @@ angular.module('Measure.services.Upload', [])
                 "Download": record.results.s2cRate,
                 "Upload": record.results.c2sRate,
                 "Latency": parseInt(record.results.MinRTT),
-                "Results": record.results
+                "Results": record.results,
+                "Annotation": record.note
             };
 
             if (record.hasOwnProperty("mlabInformation")) {

--- a/www/js/services/uploadService.js
+++ b/www/js/services/uploadService.js
@@ -2,53 +2,18 @@ angular.module('Measure.services.Upload', [])
     .factory('UploadService', function ($q, $http, SettingsService) {
         var UploadService = {};
 
-        UploadService.uploadMeasurement = function (record) {
-            // This function should never be called if the upload feature is not
-            // enabled in the extension's settings.
-            if (!SettingsService.currentSettings.uploadEnabled) {
-                return;
-            }
-
-            uploadURL = SettingsService.currentSettings.uploadURL;
-            apiKey = SettingsService.currentSettings.uploadAPIKey;
-            browserID = SettingsService.currentSettings.browserID;
-            deviceType = SettingsService.currentSettings.deviceType;
-            notes = SettingsService.currentSettings.notes;
-
-            // Generate a valid Measurement message for measure-saver.
+        UploadService.makeMeasurement = function (record) {
+            // Creates a Measurement object from a history record.
+            // Supports both versioned and unversioned records.
             ts = new Date(record.timestamp);
             var measurement = {
                 "UUID": record.uuid,
-                "BrowserID": browserID,
-                "Timestamp": ts.toISOString(),
-                "DeviceType": deviceType,
-                "Notes": notes,
                 "Download": record.results.s2cRate,
                 "Upload": record.results.c2sRate,
                 "Latency": parseInt(record.results.MinRTT),
                 "Results": record.results
             };
 
-            if (record.hasOwnProperty("accessInformation")) {
-                // If we've got client data from ipinfo, add it to the Measurement
-                // object.
-                var clientInfo = record.accessInformation;
-                measurement.ClientInfo = {}
-                measurement.ClientInfo.ASN = clientInfo.asn;
-                measurement.ClientInfo.City = clientInfo.city;
-                measurement.ClientInfo.Country = clientInfo.country;
-                measurement.ClientInfo.Hostname = clientInfo.hostname;
-                measurement.ClientInfo.IP = clientInfo.ip;
-                var coords = clientInfo.loc.split(",");
-                if (coords.length == 2) {
-                    measurement.ClientInfo.Latitude = parseFloat(coords[0]);
-                    measurement.ClientInfo.Longitude = parseFloat(coords[1]);
-                }
-                measurement.ClientInfo.ISP = clientInfo.org;
-                measurement.ClientInfo.Postal = clientInfo.postal;
-                measurement.ClientInfo.Region = clientInfo.region;
-                measurement.ClientInfo.Timezone = clientInfo.timezone;
-            }
             if (record.hasOwnProperty("mlabInformation")) {
                 // If we've got server data from mlab-ns, add it to the Measurement
                 // object.
@@ -64,6 +29,68 @@ angular.module('Measure.services.Upload', [])
                 measurement.ServerInfo.Site = serverInfo.site;
                 measurement.ServerInfo.URL = serverInfo.url;
             }
+
+            if (record.hasOwnProperty("accessInformation")) {
+                var clientInfo = record.accessInformation;
+                measurement.ClientInfo = {};
+
+                // In unversioned records, the accessInformation field comes
+                // from the now-discontinued measure-location service, which
+                // used to provide different field names.
+                if (!record.hasOwnProperty("version")) {
+                    measurement.ClientInfo.Country = clientInfo.country_name;
+                    measurement.ClientInfo.Hostname = "";
+                    measurement.ClientInfo.Latitude = clientInfo.latitude;
+                    measurement.ClientInfo.Longitude = clientInfo.longitude;
+                    measurement.ClientInfo.ISP = clientInfo.isp;
+                    measurement.ClientInfo.Postal = clientInfo.postal_code;
+                    measurement.ClientInfo.Region = clientInfo.region_code;
+                    measurement.ClientInfo.Timezone = clientInfo.time_zone;
+                } else if (record.version == 1) {
+                    measurement.ClientInfo.Country = clientInfo.country;
+                    measurement.ClientInfo.Hostname = clientInfo.hostname;
+
+                    var coords = clientInfo.loc.split(",");
+                    if (coords.length == 2) {
+                        measurement.ClientInfo.Latitude = parseFloat(coords[0]);
+                        measurement.ClientInfo.Longitude = parseFloat(coords[1]);
+                    }
+
+                    measurement.ClientInfo.ISP = clientInfo.org;
+                    measurement.ClientInfo.Postal = clientInfo.postal;
+                    measurement.ClientInfo.Region = clientInfo.region;
+                    measurement.ClientInfo.Timezone = clientInfo.timezone;
+                }
+
+                measurement.ClientInfo.IP = clientInfo.ip;
+                measurement.ClientInfo.ASN = clientInfo.asn;
+                measurement.ClientInfo.City = clientInfo.city;
+            }
+
+            return measurement;
+        };
+
+        UploadService.uploadMeasurement = function (record) {
+            // This function should never be called if the upload feature is not
+            // enabled in the extension's settings.
+            if (!SettingsService.currentSettings.uploadEnabled) {
+                return;
+            }
+
+            uploadURL = SettingsService.currentSettings.uploadURL;
+            apiKey = SettingsService.currentSettings.uploadAPIKey;
+            browserID = SettingsService.currentSettings.browserID;
+            deviceType = SettingsService.currentSettings.deviceType;
+            notes = SettingsService.currentSettings.notes;
+
+            // Generate a valid Measurement message for measure-saver.
+            var measurement = UploadService.makeMeasurement(record);
+
+            // Add measure-saver-specific metadata.
+            measurement.BrowserID = browserID;
+            measurement.Timestamp = ts.toISOString();
+            measurement.DeviceType = deviceType;
+            measurement.Notes = notes;
 
             // Add API key if configured.
             if (apiKey != "") {


### PR DESCRIPTION
CSV export used to fail in presence of a mix of old and new measurements in the
history. This fix makes sure the export works again by normalizing field names
(using the newest ones) and adding an explicit "version" field on history
records so that they can easily be distinguished.

Closes #127.
Closes #128.