### PR TITLE
sandbox-roberto-4-hour-interval

### DIFF
--- a/www/js/services/scheduleService.js
+++ b/www/js/services/scheduleService.js
@@ -17,7 +17,7 @@ angular.module('Measure.services.Schedule', [])
 
   // private helpers
   var scheduleInitializers = {
-    'daily': function() { return createIntervalSemaphore(Date.now(), 60 * 60 * 24 * 1000); },
+    'daily': function() { return createIntervalSemaphore(Date.now(), 60 * 60 * 4 * 1000); },
     'weekly': function() { return createIntervalSemaphore(Date.now(), 60 * 60 * 24 * 7 * 1000); },
     'custom': function() { return createCustomSemaphore(); }
   };


### PR DESCRIPTION
This previously meant a `[t0, t0+24h)` random interval between one test and the next one. It's now `... t0+4)` to make sure at least one measurement per day is run, especially in contexts where the machine isn't running all day.