### PR TITLE
Sort schedules in ascending order

### DIFF
--- a/www/js/services/scheduleService.js
+++ b/www/js/services/scheduleService.js
@@ -62,7 +62,7 @@ angular.module('Measure.services.Schedule', [])
 
       // next = the first schedule after "now" in the week, with wraparound (concat)
       function hourOfWeek(s) { return s.date*24+s.timespan; }
-      schedules.sort(function(a,b) { return hourOfWeek(a) < hourOfWeek(b) ? 1 : -1; });
+      schedules.sort(function(a,b) { return hourOfWeek(a) > hourOfWeek(b) ? 1 : -1; });
       var next = schedules.filter(function(s) { return hourOfWeek(s) - hourOfWeek(nowHour) > 0; }).concat(schedules)[0];
 
       var hoursToAdd = (hourOfWeek(nowHour) >= hourOfWeek(next) ? 169 /*one week in hours, plus 1 */ : 0) + hourOfWeek(next) - hourOfWeek(nowHour);


### PR DESCRIPTION
This means that when the first element in the "next" array is selected as "next run" this is actually the one that's closest to the current time. Closes #154 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-app/155)
<!-- Reviewable:end -->
