### PR TITLE
Bump version number to v0.21

### DIFF
--- a/resources/manifest.app.json
+++ b/resources/manifest.app.json
@@ -1,7 +1,7 @@
 {
   "name": "M-Lab Measure",
   "description": "Measure your Internet connection using M-Lab's Open Internet Measurement tools.",
-  "version": "0.19",
+  "version": "0.21",
   "manifest_version": 2,
   "app": {
     "background": {

--- a/resources/manifest.extension.json
+++ b/resources/manifest.extension.json
@@ -1,7 +1,7 @@
 {
   "name": "M-Lab Measure",
   "description": "Measure your Internet connection using M-Lab's Open Internet Measurement tools.",
-  "version": "0.20",
+  "version": "0.21",
   "manifest_version": 2,
   "background": {
     "scripts": [


### PR DESCRIPTION
This bumps the version number for the Chrome extension in view of a release. The only change since v0.20 is #155.

It also updates the mobile app's version number, even if AFAIK we're not building nor publishing it anywhere (which is probably why I forgot and left it one version behind when releasing 0.20).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/measure-app/156)
<!-- Reviewable:end -->
